### PR TITLE
fix: use isset() for nil checks in leaf-to-jet converter

### DIFF
--- a/rampardos/internal/templates/convert.html
+++ b/rampardos/internal/templates/convert.html
@@ -208,9 +208,14 @@
                   <td><code>&#123;&#123; object.property &#125;&#125;</code></td>
                 </tr>
                 <tr>
-                  <td>If (not nil)</td>
+                  <td>If Defined (not nil)</td>
                   <td><code>#if(var != nil):...#endif</code></td>
-                  <td><code>&#123;&#123; if var != nil &#125;&#125;...&#123;&#123; end &#125;&#125;</code></td>
+                  <td><code>&#123;&#123; if isset(var) &#125;&#125;...&#123;&#123; end &#125;&#125;</code></td>
+                </tr>
+                <tr>
+                  <td>If Not Defined (nil)</td>
+                  <td><code>#if(var == nil):...#endif</code></td>
+                  <td><code>&#123;&#123; if !isset(var) &#125;&#125;...&#123;&#123; end &#125;&#125;</code></td>
                 </tr>
                 <tr>
                   <td>If/Else If/Else</td>
@@ -225,7 +230,7 @@
                 <tr>
                   <td>Boolean AND/OR</td>
                   <td><code>#if(a != nil &amp;&amp; b):...#endif</code></td>
-                  <td><code>&#123;&#123; if a != nil &amp;&amp; b &#125;&#125;...&#123;&#123; end &#125;&#125;</code></td>
+                  <td><code>&#123;&#123; if isset(a) &amp;&amp; b &#125;&#125;...&#123;&#123; end &#125;&#125;</code></td>
                 </tr>
                 <tr>
                   <td>Loop</td>
@@ -266,6 +271,10 @@
             <p class="text-warning mb-0 mt-2">
               <i class="fas fa-exclamation-triangle"></i>
               <strong>Tip:</strong> If a variable contains a JSON string (e.g. <code>poly_path</code>), use <code>json(poly_path)</code> to parse it before iterating: <code>&#123;&#123; range i, item := json(poly_path) &#125;&#125;</code>
+            </p>
+            <p class="text-warning mb-0 mt-2">
+              <i class="fas fa-exclamation-triangle"></i>
+              <strong>Tip:</strong> Use <code>isset(var)</code> instead of <code>var != nil</code>. Jet raises an error on undefined context keys, so <code>isset()</code> is the safe way to check that an optional variable was provided.
             </p>
           </div>
         </div>

--- a/rampardos/internal/utils/leaf_to_jet.go
+++ b/rampardos/internal/utils/leaf_to_jet.go
@@ -11,6 +11,11 @@ var (
 	jetForPattern  = regexp.MustCompile(`#for\s*\(\s*(\w+)\s+in\s+(\w+(?:\.\w+)*)\s*\)\s*:`)
 	jetIndexRegex  = regexp.MustCompile(`#index\s*\(\s*([^,]+)\s*,\s*([^)]+)\s*\)`)
 	jetIndexWordRe = regexp.MustCompile(`\bindex\b`)
+	// Jet's `x != nil` does not safeguard against undefined identifiers —
+	// accessing an unset context key raises at render time. `isset(x)`
+	// is the idiomatic check and also covers the nil case.
+	jetNotNilRegex = regexp.MustCompile(`(\w+(?:\.\w+)*)\s*!=\s*nil`)
+	jetIsNilRegex  = regexp.MustCompile(`(\w+(?:\.\w+)*)\s*==\s*nil`)
 )
 
 // LeafToJetConverter converts Leaf template syntax to Jet template syntax
@@ -204,8 +209,8 @@ func (c *LeafToJetConverter) convertIfBlock(condition, body string) string {
 func (c *LeafToJetConverter) convertCondition(condition string) string {
 	condition = strings.TrimSpace(condition)
 
-	// Jet uses same operators as Go: ==, !=, etc.
-	// nil in Leaf -> nil in Jet (Jet understands nil)
+	condition = jetNotNilRegex.ReplaceAllString(condition, "isset($1)")
+	condition = jetIsNilRegex.ReplaceAllString(condition, "!isset($1)")
 
 	// Convert Leaf's magic "index" variable to Jet's "i" (from range loop)
 	// Use word boundary matching to avoid replacing "index" in "indexOf" etc.

--- a/rampardos/internal/utils/leaf_to_jet_test.go
+++ b/rampardos/internal/utils/leaf_to_jet_test.go
@@ -23,17 +23,27 @@ func TestLeafToJetConverter(t *testing.T) {
 		{
 			name:     "if not nil",
 			leaf:     `#if(var != nil):content#endif`,
-			expected: `{{ if var != nil }}content{{ end }}`,
+			expected: `{{ if isset(var) }}content{{ end }}`,
 		},
 		{
 			name:     "if nil",
 			leaf:     `#if(var == nil):content#endif`,
-			expected: `{{ if var == nil }}content{{ end }}`,
+			expected: `{{ if !isset(var) }}content{{ end }}`,
+		},
+		{
+			name:     "if not nil nested property",
+			leaf:     `#if(obj.prop != nil):content#endif`,
+			expected: `{{ if isset(obj.prop) }}content{{ end }}`,
 		},
 		{
 			name:     "if else",
 			leaf:     `#if(var != nil):yes#else:no#endif`,
-			expected: `{{ if var != nil }}yes{{ else }}no{{ end }}`,
+			expected: `{{ if isset(var) }}yes{{ else }}no{{ end }}`,
+		},
+		{
+			name:     "boolean and with nil check",
+			leaf:     `#if(a != nil && b == "x"):ok#endif`,
+			expected: `{{ if isset(a) && b == "x" }}ok{{ end }}`,
 		},
 		{
 			name:     "if elseif else",


### PR DESCRIPTION
## Summary
- `convertCondition` now rewrites `x != nil` → `isset(x)` and `x == nil` → `!isset(x)` (dotted paths included, composes inside `&&`/`||`)
- Syntax reference on `/admin/convert` updated: split "If (not nil)" into defined / not-defined rows, updated the Boolean AND/OR example, and added a tip explaining why `isset` is required (Jet errors on undefined context keys)
- Tests extended for nested-property and boolean-composition cases

Closes #3.

## Test plan
- [x] `go test ./internal/utils/` — all 16 converter cases pass
- [ ] Paste a Leaf template containing `#if(var != nil)` into `/admin/convert` and verify output uses `isset(var)`
- [ ] Render a converted template at runtime against context missing the optional key — should no longer raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)