### PR TITLE
fix: bytes-first static map pipeline (race-free, deletion-tolerant)

### DIFF
--- a/docs/superpowers/plans/2026-04-15-bytes-first-staticmap.md
+++ b/docs/superpowers/plans/2026-04-15-bytes-first-staticmap.md
@@ -1,0 +1,1596 @@
+# Bytes-First Static Map Generation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/staticmap` and `/multistaticmap` race-free and tolerant of external deletion of intermediate files by passing image bytes through the pipeline instead of re-reading disk.
+
+**Architecture:** The handler reads the base image into memory **exactly once** per request (or renders it in-memory on cache miss). Marker images are likewise held in memory between download and overlay-draw, so an admin cache-drop between those steps cannot fail the request. Overlays are drawn in memory, final bytes are written atomically. The cache index is no longer consulted for base existence (eliminating a stale-index race). The expiry queue no longer tracks `basePath` — the shared-base lifetime is owned by `CacheCleaner`'s age-based sweep. The multi-map stitcher composes from `[][]byte` returned by component generation, so components cannot disappear mid-stitch.
+
+**Scope note:** `Cache/Tile/*` is left on the disk-read path. Tile files get fresh mtime on write (age-based eviction can't touch them during the sub-second stitch window) and `loadImageWithRetry` already handles ENOENT via the `redownload` callback. The marker path has no retry equivalent, so markers graduate to bytes-in-memory; tiles do not.
+
+**Tech Stack:** Go 1.26, `golang.org/x/sync/singleflight`, `image`/`image/png`/`image/jpeg`/`image/webp`, existing `ExpiryQueue`, `CacheCleaner`, `CacheIndex`.
+
+**Branch:** `fix-race-bytes-first` off `tileserver-replacement`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|---------------|--------|
+| `rampardos/internal/utils/image_utils.go` | Public entry points for image ops | Add `GenerateStaticMapBytes`, `ComposeMultiStaticMapBytes`. Keep legacy file-path wrappers as thin shims during migration, then remove. |
+| `rampardos/internal/utils/image_utils_native.go` | Native Go impls | Add `generateStaticMapBytesNative`, `composeMultiStaticMapBytesNative`, image decode/encode helpers. Leave `GenerateBaseStaticMapNative` signature alone but have it also expose a bytes form internally. |
+| `rampardos/internal/utils/image_bytes.go` | **new** — decode/encode helpers | `decodeImage(b []byte) (image.Image, error)`, `encodeImage(img image.Image, format models.ImageFormat) ([]byte, error)`. |
+| `rampardos/internal/handlers/static_map.go` | Static-map HTTP flow | Rewrite `generateStaticMap` / `GenerateStaticMap` to return `[]byte`. Add per-basePath singleflight. Remove `baseExists` pre-check. Stop enqueueing `basePath` in expiry queue. Replace `downloadMarkers` with `downloadMarkerBytes` returning a `map[string][]byte` keyed by marker cache path. |
+| `rampardos/internal/handlers/multi_static_map.go` | Multi-map HTTP flow | Rewrite generate+stitch to operate on `[][]byte`. Remove nocache component-cleanup loop. |
+| `rampardos/internal/handlers/static_map_race_test.go` | **new** — race tests | TestExternalDeletionDuringRender, TestConcurrentSiblingBaseSingleflight. |
+| `rampardos/internal/utils/image_utils_native_test.go` | Existing image tests | Add tests for new byte-form functions. |
+
+---
+
+## Task 0: Branch + baseline
+
+**Files:** none modified; just branch + verify clean state.
+
+- [ ] **Step 1: Create branch off tileserver-replacement**
+
+```bash
+git checkout tileserver-replacement
+git pull upstream tileserver-replacement
+git checkout -b fix-race-bytes-first
+```
+
+- [ ] **Step 2: Run full test suite to confirm baseline green**
+
+```bash
+cd rampardos && go test ./...
+```
+
+Expected: all packages pass.
+
+- [ ] **Step 3: Run the existing race-shaped handler tests to confirm baseline**
+
+```bash
+cd rampardos && go test -race ./internal/handlers/...
+```
+
+Expected: PASS.
+
+---
+
+## Task 1: Image decode/encode helpers
+
+**Files:**
+- Create: `rampardos/internal/utils/image_bytes.go`
+- Test: `rampardos/internal/utils/image_bytes_test.go` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `rampardos/internal/utils/image_bytes_test.go`:
+
+```go
+package utils
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+
+	"github.com/lenisko/rampardos/internal/models"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+
+	b, err := encodeImage(img, models.ImageFormatPNG)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := decodeImage(b)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Bounds() != img.Bounds() {
+		t.Fatalf("bounds mismatch: got %v want %v", got.Bounds(), img.Bounds())
+	}
+
+	// Sanity: re-encode and parse as PNG to confirm format.
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, got); err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+}
+
+func TestDecodeInvalidBytes(t *testing.T) {
+	if _, err := decodeImage([]byte("not an image")); err == nil {
+		t.Fatal("expected error decoding garbage")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd rampardos && go test ./internal/utils/ -run TestEncodeDecodeRoundTrip -v
+```
+
+Expected: FAIL with undefined `encodeImage`/`decodeImage`.
+
+- [ ] **Step 3: Implement helpers**
+
+Create `rampardos/internal/utils/image_bytes.go`:
+
+```go
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
+
+	"github.com/gen2brain/webp"
+	"github.com/lenisko/rampardos/internal/models"
+)
+
+// decodeImage decodes PNG/JPEG/WEBP/GIF bytes via the stdlib image
+// registry (format detection is handled by the imported decoders).
+func decodeImage(b []byte) (image.Image, error) {
+	img, _, err := image.Decode(bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("decode image: %w", err)
+	}
+	return img, nil
+}
+
+// encodeImage encodes img in the requested format.
+func encodeImage(img image.Image, format models.ImageFormat) ([]byte, error) {
+	var buf bytes.Buffer
+	switch format {
+	case models.ImageFormatPNG, "":
+		if err := png.Encode(&buf, img); err != nil {
+			return nil, fmt.Errorf("png encode: %w", err)
+		}
+	case models.ImageFormatJPG, models.ImageFormatJPEG:
+		if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}); err != nil {
+			return nil, fmt.Errorf("jpeg encode: %w", err)
+		}
+	case models.ImageFormatWEBP:
+		if err := webp.Encode(&buf, img); err != nil {
+			return nil, fmt.Errorf("webp encode: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported image format %q", format)
+	}
+	return buf.Bytes(), nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd rampardos && go test ./internal/utils/ -run TestEncodeDecodeRoundTrip -v
+cd rampardos && go test ./internal/utils/ -run TestDecodeInvalidBytes -v
+```
+
+Expected: PASS for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rampardos/internal/utils/image_bytes.go rampardos/internal/utils/image_bytes_test.go
+git commit -m "feat(utils): add image decode/encode byte helpers"
+```
+
+---
+
+## Task 2: `GenerateStaticMapBytes` — in-memory overlay drawing
+
+**Files:**
+- Modify: `rampardos/internal/utils/image_utils.go` (add wrapper)
+- Modify: `rampardos/internal/utils/image_utils_native.go` (add native impl, refactor `GenerateStaticMapNative` to delegate)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `rampardos/internal/utils/image_bytes_test.go`:
+
+```go
+func TestGenerateStaticMapBytes_NoDrawables(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	baseBytes, err := encodeImage(img, models.ImageFormatPNG)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	sm := models.StaticMap{Width: 8, Height: 8, Zoom: 10, Latitude: 0, Longitude: 0, Format: models.ImageFormatPNG}
+
+	out, err := GenerateStaticMapBytes(sm, baseBytes, nil, NewSphericalMercator())
+	if err != nil {
+		t.Fatalf("GenerateStaticMapBytes: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+	if _, err := decodeImage(out); err != nil {
+		t.Fatalf("output not decodable: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd rampardos && go test ./internal/utils/ -run TestGenerateStaticMapBytes_NoDrawables -v
+```
+
+Expected: FAIL with undefined `GenerateStaticMapBytes`.
+
+- [ ] **Step 3: Add exported wrapper**
+
+In `rampardos/internal/utils/image_utils.go`, after the existing `GenerateStaticMap`:
+
+```go
+// GenerateStaticMapBytes draws overlays (markers/polygons/circles) onto
+// an already-encoded base image in memory and returns the encoded result.
+// No disk access — callers hold both the base bytes and the marker bytes
+// (keyed by the marker's cache path from getMarkerPath), so external
+// file deletion between download and draw cannot affect this path.
+// markerBytes may be nil when the staticMap has no markers.
+func GenerateStaticMapBytes(staticMap models.StaticMap, baseBytes []byte, markerBytes map[string][]byte, sm *SphericalMercator) ([]byte, error) {
+	return generateStaticMapBytesNative(staticMap, baseBytes, markerBytes, sm)
+}
+```
+
+- [ ] **Step 4: Add native impl and refactor file-path variant to delegate**
+
+In `rampardos/internal/utils/image_utils_native.go`, replace `GenerateStaticMapNative` with:
+
+```go
+// GenerateStaticMapNative is the file-path variant kept for callers that
+// still operate on disk. It delegates to the bytes variant.
+func GenerateStaticMapNative(staticMap models.StaticMap, basePath, path string, sm *SphericalMercator) error {
+	baseBytes, err := os.ReadFile(basePath)
+	if err != nil {
+		return fmt.Errorf("failed to load base image: %w", err)
+	}
+	// Legacy file-path callers pass nil marker bytes; drawOverlays
+	// falls back to disk reads via the existing loadImage path.
+	out, err := generateStaticMapBytesNative(staticMap, baseBytes, nil, sm)
+	if err != nil {
+		return err
+	}
+	return saveImageBytes(path, out)
+}
+
+// generateStaticMapBytesNative is the canonical in-memory implementation.
+// It decodes the base, draws overlays using gg, and encodes to the
+// requested format.
+func generateStaticMapBytesNative(staticMap models.StaticMap, baseBytes []byte, markerBytes map[string][]byte, sm *SphericalMercator) ([]byte, error) {
+	baseImg, err := decodeImage(baseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("decode base: %w", err)
+	}
+
+	dc := gg.NewContextForImage(baseImg)
+
+	scale := staticMap.Scale
+	if scale == 0 {
+		scale = 1
+	}
+
+	// Extract the polygon/circle/marker drawing loop from the current
+	// GenerateStaticMapNative body (lines ~132-290) into drawOverlays.
+	// Marker reads go via markerBytes if present (in-memory); otherwise
+	// fall back to loadImage(getMarkerPath(marker)) so the legacy
+	// file-path wrapper still works.
+	if err := drawOverlays(dc, staticMap, scale, markerBytes, sm); err != nil {
+		return nil, err
+	}
+
+	format := staticMap.Format
+	if format == "" {
+		format = models.ImageFormatPNG
+	}
+	return encodeImage(dc.Image(), format)
+}
+```
+
+Extract the existing overlay-drawing body into a helper `drawOverlays(dc *gg.Context, sm models.StaticMap, scale uint8, merc *SphericalMercator) error` so it can be shared. Move lines currently at `image_utils_native.go:132-290` (polygon/circle/marker processing) into the helper.
+
+Add `saveImageBytes(path string, data []byte) error` that is the byte-equivalent of `saveImage` (`os.MkdirAll` + `os.CreateTemp` + `os.Rename`):
+
+```go
+func saveImageBytes(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Run all util tests**
+
+```bash
+cd rampardos && go test ./internal/utils/
+```
+
+Expected: PASS (existing `leaf_test.go`, `leaf_to_jet_test.go`, new bytes tests, and the file-path `GenerateStaticMapNative` tests all pass — the refactor is pure behaviour-preserving).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rampardos/internal/utils/image_utils.go rampardos/internal/utils/image_utils_native.go rampardos/internal/utils/image_bytes_test.go
+git commit -m "feat(utils): bytes-first GenerateStaticMapBytes with file-path wrapper"
+```
+
+---
+
+## Task 3: `generateBaseStaticMap*` return bytes
+
+**Files:**
+- Modify: `rampardos/internal/handlers/static_map.go` (methods `generateBaseStaticMapFromAPI`, `generateBaseStaticMapFromTiles`, `generateBaseStaticMap`)
+
+**Context:** Currently these methods write directly to `basePath`. Refactor so they **return bytes** and let the caller decide whether to persist. This lets the single-map flow hold bytes in memory without re-reading.
+
+- [ ] **Step 1: Change signatures — return `([]byte, error)`**
+
+In `rampardos/internal/handlers/static_map.go`:
+
+```go
+// generateBaseStaticMap renders the base image (without overlays) and
+// returns the encoded bytes. Callers are responsible for persisting if
+// they want caching.
+func (h *StaticMapHandler) generateBaseStaticMap(ctx context.Context, staticMap models.StaticMap) ([]byte, error) {
+	extStyle := h.stylesController.GetExternalStyle(staticMap.Style)
+
+	if extStyle == nil {
+		if isFractional(staticMap.Zoom) {
+			return h.generateBaseStaticMapFromAPIFn(ctx, staticMap)
+		}
+		return h.generateBaseStaticMapFromTilesFn(ctx, staticMap, extStyle)
+	}
+	// External style: fractional zoom uses external proxy, integer uses tiles.
+	if isFractional(staticMap.Zoom) {
+		return h.generateBaseStaticMapFromAPIFn(ctx, staticMap)
+	}
+	return h.generateBaseStaticMapFromTilesFn(ctx, staticMap, extStyle)
+}
+```
+
+Update the hook types:
+
+```go
+generateBaseStaticMapFromAPIFn   func(ctx context.Context, sm models.StaticMap) ([]byte, error)
+generateBaseStaticMapFromTilesFn func(ctx context.Context, sm models.StaticMap, extStyle *models.Style) ([]byte, error)
+```
+
+- [ ] **Step 2: Update `generateBaseStaticMapFromAPI` body to return bytes**
+
+Find the existing method (renders via `renderer.RenderViewport` then writes to disk). Change the tail from "write to `basePath`" to "return the rendered bytes". The renderer already returns `[]byte` from `Render`/`RenderViewport`, so the change is: drop the `os.WriteFile(basePath, data, 0644)` / `atomicWriteFile` call and `return data, nil` instead.
+
+- [ ] **Step 3: Update `generateBaseStaticMapFromTiles` body to return bytes**
+
+This method currently composes tiles into an image and writes `basePath`. Refactor to call a new `utils.ComposeBaseStaticMapBytes(...)` that returns `[]byte`. Add that new utility in `rampardos/internal/utils/image_utils.go`:
+
+```go
+// ComposeBaseStaticMapBytes stitches and crops tile images into the
+// final base, returning encoded bytes. Equivalent to
+// GenerateBaseStaticMap but without touching disk.
+func ComposeBaseStaticMapBytes(staticMap models.StaticMap, tilePaths []string, offsetX, offsetY int, hasScale bool, redownload TileRedownloader) ([]byte, error) {
+	return composeBaseStaticMapBytesNative(staticMap, tilePaths, offsetX, offsetY, hasScale, redownload)
+}
+```
+
+In `rampardos/internal/utils/image_utils_native.go`, extract lines `27-123` of the existing `GenerateBaseStaticMapNative` into `composeBaseStaticMapBytesNative` that returns `([]byte, error)` (replacing the final `return saveImage(path, cropped)` with `return encodeImage(cropped, format)`). Have `GenerateBaseStaticMapNative` become a thin shim that calls the bytes form then `saveImageBytes`:
+
+```go
+func GenerateBaseStaticMapNative(staticMap models.StaticMap, tilePaths []string, path string, offsetX, offsetY int, hasScale bool, redownload TileRedownloader) error {
+	b, err := composeBaseStaticMapBytesNative(staticMap, tilePaths, offsetX, offsetY, hasScale, redownload)
+	if err != nil {
+		return err
+	}
+	return saveImageBytes(path, b)
+}
+```
+
+- [ ] **Step 4: Update caller wiring in `NewStaticMapHandler`**
+
+No change needed — the hooks still point to methods; only the signatures change. Verify that the assignments in `NewStaticMapHandler` still compile after the signature change.
+
+- [ ] **Step 5: Run test suite**
+
+```bash
+cd rampardos && go test ./...
+```
+
+Expected: PASS. Any existing handler tests that override `generateBaseStaticMap*Fn` need their hook signatures updated to match.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rampardos/internal/handlers/static_map.go rampardos/internal/utils/image_utils.go rampardos/internal/utils/image_utils_native.go
+git commit -m "refactor(handlers): base static map generators return bytes"
+```
+
+---
+
+## Task 4: Bytes-first `generateStaticMap` with per-basePath singleflight
+
+**Files:**
+- Modify: `rampardos/internal/handlers/static_map.go`
+
+- [ ] **Step 1: Add basePath singleflight field**
+
+In the `StaticMapHandler` struct, add a second singleflight group dedicated to base rendering:
+
+```go
+type StaticMapHandler struct {
+	// ...existing fields...
+	sfg     singleflight.Group // dedupe final path
+	baseSfg singleflight.Group // dedupe base rendering for concurrent siblings
+	// ...
+}
+```
+
+- [ ] **Step 2: Add `loadOrRenderBaseBytes` helper**
+
+```go
+// loadOrRenderBaseBytes returns the base image for staticMap. If
+// basePath exists on disk, its bytes are read once. Otherwise the
+// base is rendered in memory and best-effort persisted. Concurrent
+// callers for the same basePath are deduplicated.
+func (h *StaticMapHandler) loadOrRenderBaseBytes(ctx context.Context, staticMap models.StaticMap, basePath string) ([]byte, error) {
+	v, err, _ := h.baseSfg.Do(basePath, func() (any, error) {
+		if b, err := os.ReadFile(basePath); err == nil {
+			return b, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("read base: %w", err)
+		}
+		b, err := h.generateBaseStaticMap(ctx, staticMap)
+		if err != nil {
+			return nil, err
+		}
+		// Best-effort persist. Failure is non-fatal: the request
+		// succeeds with bytes in hand; cache miss penalty falls on the
+		// next request.
+		if writeErr := utils.SaveImageBytes(basePath, b); writeErr != nil {
+			slog.Warn("Failed to cache base image", "path", basePath, "error", writeErr)
+		}
+		return b, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.([]byte), nil
+}
+```
+
+(Export `saveImageBytes` as `SaveImageBytes` in Task 2 — update that task's Step 4 to use the exported name. Already consistent below.)
+
+- [ ] **Step 3: Rewrite `generateStaticMap` to return bytes**
+
+Replace the existing `generateStaticMap` (lines ~365-398) with:
+
+```go
+// generateStaticMap produces the final static map bytes and, on cache
+// paths, persists them. Returns the final bytes so the caller can
+// serve from memory without a second disk read (closing the last race
+// window between write and serve).
+func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath string, staticMap models.StaticMap) ([]byte, error) {
+	hasDrawables := len(staticMap.Markers) > 0 || len(staticMap.Polygons) > 0 || len(staticMap.Circles) > 0
+
+	baseBytes, err := h.loadOrRenderBaseBytes(ctx, staticMap, basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// No drawables: final image == base image.
+	if !hasDrawables {
+		if path != basePath {
+			if err := utils.SaveImageBytes(path, baseBytes); err != nil {
+				return nil, err
+			}
+		}
+		return baseBytes, nil
+	}
+
+	markerBytes, err := h.downloadMarkerBytes(ctx, staticMap)
+	if err != nil {
+		return nil, err
+	}
+
+	finalBytes, err := utils.GenerateStaticMapBytes(staticMap, baseBytes, markerBytes, h.sphericalMercator)
+	if err != nil {
+		return nil, err
+	}
+	if err := utils.SaveImageBytes(path, finalBytes); err != nil {
+		return nil, err
+	}
+	return finalBytes, nil
+}
+```
+
+- [ ] **Step 4: Update `handleRequest` to use new signature**
+
+In `handleRequest` (lines 266-282 area), replace:
+
+```go
+_, genErr, _ := h.sfg.Do(path, func() (any, error) {
+	if _, err := os.Stat(path); err == nil {
+		return nil, nil
+	}
+	baseExists := false
+	if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasStaticMap(basePath) {
+		baseExists = true
+	} else if _, err := os.Stat(basePath); err == nil {
+		baseExists = true
+		if services.GlobalCacheIndex != nil {
+			services.GlobalCacheIndex.AddStaticMap(basePath)
+		}
+	}
+	return nil, h.generateStaticMap(r.Context(), path, basePath, baseExists, staticMap)
+})
+```
+
+with:
+
+```go
+v, genErr, _ := h.sfg.Do(path, func() (any, error) {
+	if _, err := os.Stat(path); err == nil {
+		return os.ReadFile(path)
+	}
+	return h.generateStaticMap(r.Context(), path, basePath, staticMap)
+})
+
+var finalBytes []byte
+if genErr == nil && v != nil {
+	finalBytes, _ = v.([]byte)
+}
+```
+
+Note: the cache index is still updated *after* a successful generate (existing code path), but we no longer consult it for base existence. The index now purely signals "final path is on disk" for the fast path at line ~243.
+
+- [ ] **Step 5: Update `GenerateStaticMap` (exported, multi-map entry) to return bytes**
+
+Change:
+
+```go
+func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap models.StaticMap, opts GenerateOpts) ([]byte, error)
+```
+
+Body:
+
+```go
+func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap models.StaticMap, opts GenerateOpts) ([]byte, error) {
+	path := staticMap.Path()
+	basePath := staticMap.BasePath()
+
+	if !opts.NoCache {
+		if b, err := os.ReadFile(path); err == nil {
+			return b, nil
+		}
+	}
+
+	v, err, _ := h.sfg.Do(path, func() (any, error) {
+		if !opts.NoCache {
+			if b, err := os.ReadFile(path); err == nil {
+				return b, nil
+			}
+		}
+		return h.generateStaticMap(ctx, path, basePath, staticMap)
+	})
+	if err != nil {
+		return nil, err
+	}
+	finalBytes, _ := v.([]byte)
+
+	// TTL tracking: only the final path is owned by this caller.
+	// basePath is a shared resource governed by CacheCleaner age eviction.
+	if !opts.NoCache && opts.TTL > 0 && services.GlobalExpiryQueue != nil {
+		cleanupIndex := func() {
+			if services.GlobalCacheIndex != nil {
+				services.GlobalCacheIndex.RemoveStaticMap(path)
+			}
+		}
+		services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path)
+	}
+	return finalBytes, nil
+}
+```
+
+- [ ] **Step 6: Remove `baseExists` plumbing from the old singleflight section in `handleRequest` (already done in Step 4) and drop the now-unused `baseExists` bool paths.**
+
+- [ ] **Step 7: Serve from memory when possible in `handleRequest`**
+
+After the singleflight block, replace `h.generateResponse(w, r, staticMap, path)` (success path, line ~313) with a helper that prefers in-memory bytes:
+
+```go
+h.generateResponseBytes(w, r, staticMap, path, finalBytes)
+```
+
+Add:
+
+```go
+func (h *StaticMapHandler) generateResponseBytes(w http.ResponseWriter, r *http.Request, staticMap models.StaticMap, path string, finalBytes []byte) {
+	if handlePregenerateResponse(w, r, path, staticMap) {
+		return
+	}
+	if finalBytes != nil {
+		// Serve directly from memory to close the race window between
+		// atomic-write and serve: external deletion of path does not
+		// affect this response.
+		w.Header().Set("Content-Type", contentTypeFor(staticMap.Format))
+		w.Header().Set("Content-Length", strconv.Itoa(len(finalBytes)))
+		_, _ = w.Write(finalBytes)
+		return
+	}
+	serveFile(w, r, path)
+}
+```
+
+Add `contentTypeFor(format)` in `rampardos/internal/handlers/common.go`:
+
+```go
+func contentTypeFor(format models.ImageFormat) string {
+	switch format {
+	case models.ImageFormatJPG, models.ImageFormatJPEG:
+		return "image/jpeg"
+	case models.ImageFormatWEBP:
+		return "image/webp"
+	default:
+		return "image/png"
+	}
+}
+```
+
+- [ ] **Step 8: Remove `basePath` from TTL expiry queue in `handleRequest`**
+
+In `handleRequest`, the existing block:
+
+```go
+if path != basePath {
+	services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path, basePath)
+} else {
+	services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
+}
+```
+
+becomes:
+
+```go
+services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
+```
+
+(The base is shared state; let `CacheCleaner`'s age-based sweep own its lifetime.)
+
+- [ ] **Step 9: Build + test**
+
+```bash
+cd rampardos && go build ./... && go test -race ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add rampardos/internal/handlers/static_map.go rampardos/internal/handlers/common.go
+git commit -m "refactor(handlers): bytes-first single static map flow
+
+- Read basePath into memory once; on miss, render in-memory and
+  best-effort persist.
+- Deduplicate concurrent base renders via a second singleflight
+  keyed on basePath.
+- Drop GlobalCacheIndex as the source of truth for base existence
+  (stale entries caused false positives leading to read-after-delete).
+- Serve final image from in-memory bytes when available.
+- Remove basePath from the per-request ExpiryQueue; the base is a
+  shared resource owned by CacheCleaner age eviction."
+```
+
+---
+
+## Task 4b: `downloadMarkerBytes` — markers held in memory
+
+**Files:**
+- Modify: `rampardos/internal/handlers/static_map.go` (replace `downloadMarkers` semantics)
+- Modify: `rampardos/internal/utils/image_utils_native.go` (update `drawOverlays` to use `markerBytes` when provided)
+- Modify: `rampardos/internal/utils/image_utils.go` (export `GetMarkerPath` / `GetFallbackMarkerPath` if not already; used by handler)
+
+**Context:** `downloadMarkers` currently writes marker PNGs to `Cache/Marker/<hash>.ext` and the overlay draw re-reads them. A `CacheCleaner` sweep on `Cache/Marker` between download and draw causes a hard failure with no retry. This task holds the marker bytes in memory through the draw, closing that window.
+
+- [ ] **Step 1: Export marker path helpers for handler use**
+
+In `rampardos/internal/utils/image_utils.go`, export the existing `getMarkerPath` / `getFallbackMarkerPath` as `GetMarkerPath` / `GetFallbackMarkerPath` (same bodies). Update the sole internal caller in `image_utils_native.go`. Run:
+
+```bash
+grep -rn "getMarkerPath\|getFallbackMarkerPath" rampardos/internal/
+```
+
+Expected: only the renamed identifiers remain.
+
+- [ ] **Step 2: Write failing test for `downloadMarkerBytes`**
+
+Add to a new or existing test file `rampardos/internal/handlers/marker_bytes_test.go`:
+
+```go
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lenisko/rampardos/internal/models"
+	"github.com/lenisko/rampardos/internal/utils"
+)
+
+func TestDownloadMarkerBytes_ServesFromMemory(t *testing.T) {
+	// Serve a 1x1 PNG from an httptest server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(fakePNG(t))
+	}))
+	defer srv.Close()
+
+	h, cleanup := newTestStaticMapHandler(t)
+	defer cleanup()
+
+	sm := models.StaticMap{
+		Markers: []models.Marker{{URL: srv.URL + "/a.png", Latitude: 0, Longitude: 0}},
+	}
+
+	got, err := h.downloadMarkerBytes(context.Background(), sm)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	key := utils.GetMarkerPath(sm.Markers[0])
+	if len(got[key]) == 0 {
+		t.Fatalf("expected bytes for %s; got map %v", key, got)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd rampardos && go test ./internal/handlers/ -run TestDownloadMarkerBytes_ServesFromMemory -v
+```
+
+Expected: FAIL (undefined `downloadMarkerBytes`).
+
+- [ ] **Step 4: Implement `downloadMarkerBytes`**
+
+In `rampardos/internal/handlers/static_map.go`, replace `downloadMarkers` with:
+
+```go
+// downloadMarkerBytes fetches each marker (and fallback, if present) and
+// returns a map keyed by the marker's cache path. If the marker is
+// already cached on disk, its bytes are read once and reused. If the
+// marker must be downloaded, it is written atomically to Cache/Marker
+// and the bytes are retained in the returned map.
+//
+// Callers pass the map to utils.GenerateStaticMapBytes so the overlay
+// draw never touches Cache/Marker — closing the race between
+// CacheCleaner and draw.
+func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap models.StaticMap) (map[string][]byte, error) {
+	if len(staticMap.Markers) == 0 {
+		return nil, nil
+	}
+	out := make(map[string][]byte, len(staticMap.Markers))
+	for _, m := range staticMap.Markers {
+		key := utils.GetMarkerPath(m)
+		if _, ok := out[key]; ok {
+			continue // same URL reused across markers
+		}
+		b, err := h.fetchMarkerBytes(ctx, m.URL, key)
+		if err != nil && m.FallbackURL != "" {
+			fbKey := utils.GetFallbackMarkerPath(m)
+			if fb, fbErr := h.fetchMarkerBytes(ctx, m.FallbackURL, fbKey); fbErr == nil {
+				out[key] = fb // fallback bytes served under primary key
+				continue
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("marker %s: %w", m.URL, err)
+		}
+		out[key] = b
+	}
+	return out, nil
+}
+
+// fetchMarkerBytes returns bytes for a remote marker URL, caching to
+// diskPath atomically when missing. For non-URL markers (bundled
+// Markers/* files), diskPath is read directly.
+func (h *StaticMapHandler) fetchMarkerBytes(ctx context.Context, url, diskPath string) ([]byte, error) {
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		// Bundled marker — read from disk (assumed stable, not in Cache/Marker).
+		return os.ReadFile(diskPath)
+	}
+	if b, err := os.ReadFile(diskPath); err == nil {
+		return b, nil
+	}
+	b, err := services.GlobalHTTPService.GetBytes(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	if err := utils.SaveImageBytes(diskPath, b); err != nil {
+		slog.Warn("Failed to cache marker", "path", diskPath, "error", err)
+	}
+	return b, nil
+}
+```
+
+If `services.GlobalHTTPService.GetBytes` does not exist, add it as a thin wrapper around the existing downloader:
+
+```go
+// GetBytes fetches a URL and returns the body as bytes (no disk writes).
+func (s *HTTPService) GetBytes(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+```
+
+- [ ] **Step 5: Update `drawOverlays` to consume `markerBytes`**
+
+In `rampardos/internal/utils/image_utils_native.go`, inside the marker draw loop, replace:
+
+```go
+markerImg, err := loadImage(utils.GetMarkerPath(marker))
+```
+
+with:
+
+```go
+var markerImg image.Image
+if b, ok := markerBytes[GetMarkerPath(marker)]; ok {
+	markerImg, err = decodeImage(b)
+} else {
+	// Legacy path: no markerBytes provided, fall back to disk.
+	markerImg, err = loadImage(GetMarkerPath(marker))
+}
+```
+
+Apply the same pattern to any fallback-marker branch.
+
+- [ ] **Step 6: Delete the old `downloadMarkers` method**
+
+It's no longer called. Remove the function entirely. `grep` to confirm no remaining references:
+
+```bash
+grep -rn "\.downloadMarkers\b" rampardos/internal/
+```
+
+Expected: no hits.
+
+- [ ] **Step 7: Build + race test**
+
+```bash
+cd rampardos && go build ./... && go test -race ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Race test — marker deleted between download and draw**
+
+Add to `rampardos/internal/handlers/marker_bytes_test.go`:
+
+```go
+func TestMarkerDeletedBetweenDownloadAndDrawDoesNotFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(fakePNG(t))
+	}))
+	defer srv.Close()
+
+	h, cleanup := newTestStaticMapHandler(t)
+	defer cleanup()
+
+	sm := testStaticMap("m")
+	sm.Markers = []models.Marker{{URL: srv.URL + "/a.png", Latitude: sm.Latitude, Longitude: sm.Longitude}}
+
+	markers, err := h.downloadMarkerBytes(context.Background(), sm)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+
+	// Simulate CacheCleaner nuking Cache/Marker before the draw.
+	key := utils.GetMarkerPath(sm.Markers[0])
+	_ = os.Remove(key)
+
+	// Render must still succeed because markers are in memory.
+	baseBytes := fakePNG(t)
+	if _, err := utils.GenerateStaticMapBytes(sm, baseBytes, markers, utils.NewSphericalMercator()); err != nil {
+		t.Fatalf("render after marker deletion: %v", err)
+	}
+}
+```
+
+- [ ] **Step 9: Run the race test**
+
+```bash
+cd rampardos && go test -race ./internal/handlers/ -run TestMarkerDeletedBetweenDownloadAndDrawDoesNotFail -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add rampardos/internal/handlers/static_map.go rampardos/internal/handlers/marker_bytes_test.go rampardos/internal/utils/image_utils.go rampardos/internal/utils/image_utils_native.go rampardos/internal/services/http.go
+git commit -m "feat(handlers): hold marker bytes in memory through overlay draw
+
+Replaces downloadMarkers with downloadMarkerBytes, which returns a
+map[string][]byte keyed by marker cache path. The overlay draw reads
+from the map instead of disk, closing the CacheCleaner-vs-draw race
+window that previously caused hard failures with no retry."
+```
+
+---
+
+## Task 5: Race test — external deletion during render
+
+**Files:**
+- Create: `rampardos/internal/handlers/static_map_race_test.go`
+
+- [ ] **Step 1: Write failing test (fails *before* the new behaviour landed, passes after)**
+
+```go
+package handlers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/lenisko/rampardos/internal/models"
+)
+
+// TestBaseDeletedBetweenCallsDoesNotError verifies that if the base
+// image file is deleted externally between two GenerateStaticMap
+// calls for the same basePath (but different paths), the second call
+// still succeeds because we no longer trust a stale cache-index entry.
+func TestBaseDeletedBetweenCallsDoesNotError(t *testing.T) {
+	h, cleanup := newTestStaticMapHandler(t)
+	defer cleanup()
+
+	smA := testStaticMap("a")
+	smB := testStaticMap("b") // same coords/zoom/style → same basePath, different overlay markers → different path
+
+	ctx := context.Background()
+
+	if _, err := h.GenerateStaticMap(ctx, smA, GenerateOpts{}); err != nil {
+		t.Fatalf("first generate: %v", err)
+	}
+
+	// External deletion of the shared base.
+	if err := os.Remove(smA.BasePath()); err != nil {
+		t.Fatalf("remove base: %v", err)
+	}
+
+	if _, err := h.GenerateStaticMap(ctx, smB, GenerateOpts{}); err != nil {
+		t.Fatalf("second generate after base delete: %v", err)
+	}
+
+	// Final file for B should exist.
+	if _, err := os.Stat(smB.Path()); err != nil {
+		t.Fatalf("expected final path for B: %v", err)
+	}
+}
+
+// TestConcurrentSiblingBaseSingleflight verifies that N concurrent
+// requests for different paths but the same basePath render the base
+// exactly once.
+func TestConcurrentSiblingBaseSingleflight(t *testing.T) {
+	h, cleanup := newTestStaticMapHandler(t)
+	defer cleanup()
+
+	var renders int
+	h.generateBaseStaticMapFromTilesFn = func(ctx context.Context, sm models.StaticMap, _ *models.Style) ([]byte, error) {
+		renders++
+		return fakePNG(t), nil
+	}
+
+	const N = 8
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sm := testStaticMap(string(rune('a' + i))) // different paths
+			if _, err := h.GenerateStaticMap(context.Background(), sm, GenerateOpts{}); err != nil {
+				t.Errorf("generate %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if renders != 1 {
+		t.Fatalf("expected 1 base render, got %d", renders)
+	}
+}
+```
+
+Helpers needed: `newTestStaticMapHandler(t)` (constructs a handler with fake renderer + tmp dirs), `testStaticMap(tag)` (builds a `models.StaticMap` with stable coords + a marker whose URL contains `tag` so `Path()` varies), `fakePNG(t)` (returns a valid 8x8 PNG).
+
+Place these in a shared `static_map_testhelpers_test.go` file if not already present.
+
+- [ ] **Step 2: Run tests — they should PASS**
+
+```bash
+cd rampardos && go test -race ./internal/handlers/ -run TestBaseDeletedBetweenCallsDoesNotError -v
+cd rampardos && go test -race ./internal/handlers/ -run TestConcurrentSiblingBaseSingleflight -v
+```
+
+Expected: PASS (because Task 4 landed the bytes-first behaviour and basePath singleflight).
+
+- [ ] **Step 3: Sanity — run against pre-Task-4 commit to confirm the test is meaningful**
+
+```bash
+git stash
+git checkout HEAD~1 -- rampardos/internal/handlers/static_map.go
+cd rampardos && go test ./internal/handlers/ -run TestBaseDeletedBetweenCallsDoesNotError
+# Expected: FAIL (stale index hit)
+git checkout HEAD -- rampardos/internal/handlers/static_map.go
+git stash pop
+```
+
+(If the fail mode doesn't reproduce due to `CacheIndex` init ordering in the test harness, it's enough that the test passes post-fix. Skip if painful.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rampardos/internal/handlers/static_map_race_test.go rampardos/internal/handlers/static_map_testhelpers_test.go
+git commit -m "test(handlers): race tests for external base deletion and sibling singleflight"
+```
+
+---
+
+## Task 6: `utils.ComposeMultiStaticMapBytes` — stitch from `[][]byte`
+
+**Files:**
+- Modify: `rampardos/internal/utils/image_utils.go` (add wrapper)
+- Modify: `rampardos/internal/utils/image_utils_native.go` (add impl, refactor `GenerateMultiStaticMapNative`)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `rampardos/internal/utils/image_bytes_test.go`:
+
+```go
+func TestComposeMultiStaticMapBytes_TwoHorizontal(t *testing.T) {
+	red := imageBytes(t, color.RGBA{R: 255, A: 255})
+	blue := imageBytes(t, color.RGBA{B: 255, A: 255})
+
+	msm := models.MultiStaticMap{
+		Grid: []models.MultiStaticMapGrid{
+			{
+				Direction: models.CombineDirectionFirst,
+				Maps: []models.MultiStaticMapItem{
+					{Map: models.StaticMap{}, Direction: models.CombineDirectionFirst},
+					{Map: models.StaticMap{}, Direction: models.CombineDirectionRight},
+				},
+			},
+		},
+	}
+
+	out, err := ComposeMultiStaticMapBytes(msm, [][]byte{red, blue})
+	if err != nil {
+		t.Fatalf("compose: %v", err)
+	}
+	got, err := decodeImage(out)
+	if err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if got.Bounds().Dx() != 16 || got.Bounds().Dy() != 8 {
+		t.Fatalf("bounds: got %v want 16x8", got.Bounds())
+	}
+}
+
+func imageBytes(t *testing.T, c color.Color) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	draw.Draw(img, img.Bounds(), &image.Uniform{C: c}, image.Point{}, draw.Src)
+	b, err := encodeImage(img, models.ImageFormatPNG)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return b
+}
+```
+
+Add missing imports (`image/color`, `image/draw`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd rampardos && go test ./internal/utils/ -run TestComposeMultiStaticMapBytes_TwoHorizontal -v
+```
+
+Expected: FAIL (undefined).
+
+- [ ] **Step 3: Add exported wrapper**
+
+In `image_utils.go`:
+
+```go
+// ComposeMultiStaticMapBytes composes pre-encoded component images
+// into the final grid image. componentBytes must be in grid iteration
+// order (outer: grids, inner: maps within each grid, flattened).
+func ComposeMultiStaticMapBytes(multiStaticMap models.MultiStaticMap, componentBytes [][]byte) ([]byte, error) {
+	return composeMultiStaticMapBytesNative(multiStaticMap, componentBytes)
+}
+```
+
+- [ ] **Step 4: Add native impl; refactor `GenerateMultiStaticMapNative` to shim**
+
+In `image_utils_native.go`, extract the existing body of `GenerateMultiStaticMapNative` into `composeMultiStaticMapBytesNative` that takes `componentBytes [][]byte`, replacing each `loadImage(mapPath)` with `decodeImage(componentBytes[k])` (indexed by flat order). Final `saveImage(path, result)` becomes `encodeImage(result, models.ImageFormatPNG)`.
+
+Rewrite `GenerateMultiStaticMapNative` as:
+
+```go
+func GenerateMultiStaticMapNative(multiStaticMap models.MultiStaticMap, path string) error {
+	// Legacy file-path entrypoint: read components from disk, compose, save.
+	var componentBytes [][]byte
+	for _, grid := range multiStaticMap.Grid {
+		for _, m := range grid.Maps {
+			b, err := os.ReadFile(m.Map.Path())
+			if err != nil {
+				return fmt.Errorf("failed to load map %s: %w", m.Map.Path(), err)
+			}
+			componentBytes = append(componentBytes, b)
+		}
+	}
+	out, err := composeMultiStaticMapBytesNative(multiStaticMap, componentBytes)
+	if err != nil {
+		return err
+	}
+	return saveImageBytes(path, out)
+}
+```
+
+- [ ] **Step 5: Run util tests**
+
+```bash
+cd rampardos && go test ./internal/utils/
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rampardos/internal/utils/image_utils.go rampardos/internal/utils/image_utils_native.go rampardos/internal/utils/image_bytes_test.go
+git commit -m "feat(utils): bytes-first ComposeMultiStaticMapBytes"
+```
+
+---
+
+## Task 7: Multi-static handler — parallel bytes fetch + in-memory compose
+
+**Files:**
+- Modify: `rampardos/internal/handlers/multi_static_map.go`
+
+- [ ] **Step 1: Rewrite the generate+combine section in `handleRequest`**
+
+Replace the `h.sfg.Do(path, ...)` block (lines ~180-229 in current `multi_static_map.go`) with:
+
+```go
+v, sfErr, _ := h.sfg.Do(path, func() (any, error) {
+	if !skipCache {
+		if b, err := os.ReadFile(path); err == nil {
+			return b, nil
+		}
+	}
+
+	// Flatten component order.
+	var components []models.StaticMap
+	for _, grid := range multiStaticMap.Grid {
+		for _, m := range grid.Maps {
+			components = append(components, m.Map)
+		}
+	}
+
+	// Component opts flow-through: nocache/ttl apply to cacheable
+	// components. With skipCache, components return bytes and are not
+	// persisted to disk at all.
+	componentOpts := GenerateOpts{NoCache: skipCache}
+	if ttlSeconds > 0 {
+		componentOpts.TTL = time.Duration(ttlSeconds) * time.Second
+	}
+
+	// Parallel component generation, preserving slot order for the stitcher.
+	componentBytes := make([][]byte, len(components))
+	errCh := make(chan error, len(components))
+	sem := make(chan struct{}, 5)
+	var wg sync.WaitGroup
+	for i, sm := range components {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, sm models.StaticMap) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			b, err := h.staticMapHandler.GenerateStaticMap(r.Context(), sm, componentOpts)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			componentBytes[i] = b
+		}(i, sm)
+	}
+	wg.Wait()
+	close(errCh)
+	if err, ok := <-errCh; ok {
+		return nil, err
+	}
+
+	stitched, err := utils.ComposeMultiStaticMapBytes(multiStaticMap, componentBytes)
+	if err != nil {
+		return nil, err
+	}
+	if !skipCache {
+		if err := utils.SaveImageBytes(path, stitched); err != nil {
+			return nil, err
+		}
+	}
+	return stitched, nil
+})
+```
+
+After the block, update the response path to serve from memory:
+
+```go
+if sfErr != nil {
+	// ...existing error handling...
+}
+
+var stitched []byte
+if v != nil {
+	stitched, _ = v.([]byte)
+}
+
+duration := time.Since(startTime).Seconds()
+h.statsController.StaticMapServed(true, path, "multi")
+services.GlobalMetrics.RecordRequest("multistaticmap", "multi", false, duration)
+
+if skipCache {
+	// nocache: serve bytes directly, never touching disk.
+	slog.Debug("Served multi-static map (nocache)", "file", filepath.Base(path), "maps", len(stitched), "duration", duration)
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Content-Length", strconv.Itoa(len(stitched)))
+	_, _ = w.Write(stitched)
+	return
+}
+
+if services.GlobalCacheIndex != nil {
+	services.GlobalCacheIndex.AddMultiStaticMap(path)
+}
+slog.Debug("Served multi-static map (generated)", "file", filepath.Base(path), "duration", duration, "ttl", ttlSeconds)
+h.generateResponseBytes(w, r, multiStaticMap, path, stitched)
+
+if ttlSeconds > 0 && services.GlobalExpiryQueue != nil {
+	cleanupIndex := func() {
+		if services.GlobalCacheIndex != nil {
+			services.GlobalCacheIndex.RemoveMultiStaticMap(path)
+		}
+	}
+	services.GlobalExpiryQueue.Add(time.Duration(ttlSeconds)*time.Second, cleanupIndex, path)
+}
+```
+
+Add `generateResponseBytes` on `MultiStaticMapHandler` mirroring the single-map helper:
+
+```go
+func (h *MultiStaticMapHandler) generateResponseBytes(w http.ResponseWriter, r *http.Request, msm models.MultiStaticMap, path string, stitched []byte) {
+	if handlePregenerateResponse(w, r, path, msm) {
+		return
+	}
+	if stitched != nil {
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Length", strconv.Itoa(len(stitched)))
+		_, _ = w.Write(stitched)
+		return
+	}
+	serveFile(w, r, path)
+}
+```
+
+- [ ] **Step 2: Remove the old component-file-cleanup block**
+
+The existing loop:
+
+```go
+if skipCache {
+	for _, sm := range mapsToGenerate {
+		os.Remove(sm.Path())
+		bp := sm.BasePath()
+		if bp != sm.Path() {
+			os.Remove(bp)
+		}
+	}
+}
+```
+
+is no longer needed — with `componentOpts.NoCache = true`, components never hit disk. Delete it.
+
+- [ ] **Step 3: Build + test**
+
+```bash
+cd rampardos && go build ./... && go test -race ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rampardos/internal/handlers/multi_static_map.go
+git commit -m "refactor(handlers): bytes-first multi static map flow
+
+Components are fetched as [][]byte in parallel, composed in memory,
+and written atomically. Eliminates the read-after-delete race where
+a TTL sweep could remove a component file between GenerateStaticMap
+and the stitcher's load. With nocache, components never touch disk."
+```
+
+---
+
+## Task 8: `GenerateStaticMap(ctx, sm, opts) ([]byte, error)` — support nocache bytes path
+
+**Files:**
+- Modify: `rampardos/internal/handlers/static_map.go` (already touched in Task 4, but now we need the explicit nocache bytes path for multi components)
+
+- [ ] **Step 1: Add nocache branch in `GenerateStaticMap`**
+
+Ensure `GenerateStaticMap` (from Task 4) honours `opts.NoCache` by **not** writing to disk for the no-drawable case. Update `generateStaticMap` (unexported) to accept an explicit "persist?" argument:
+
+```go
+func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath string, staticMap models.StaticMap, persist bool) ([]byte, error) {
+	// ...as Task 4, but gate every SaveImageBytes call on `persist`...
+}
+```
+
+Update both call sites (`handleRequest` passes `persist: true`; `GenerateStaticMap` passes `persist: !opts.NoCache`).
+
+- [ ] **Step 2: Build + test**
+
+```bash
+cd rampardos && go test -race ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rampardos/internal/handlers/static_map.go
+git commit -m "feat(handlers): GenerateStaticMap honours NoCache by not persisting"
+```
+
+---
+
+## Task 9: Multi-map race test
+
+**Files:**
+- Modify: `rampardos/internal/handlers/static_map_race_test.go` (append) or new file.
+
+- [ ] **Step 1: Add test**
+
+```go
+// TestMultiStaticMapComponentDeletedMidFlight verifies the stitcher
+// composes from in-memory bytes and is not affected by concurrent
+// deletion of component files.
+func TestMultiStaticMapComponentDeletedMidFlight(t *testing.T) {
+	sh, mh, cleanup := newTestMultiStaticMapHandler(t)
+	defer cleanup()
+	_ = sh
+
+	msm := testMultiStaticMap()
+	// Pre-create the components on disk.
+	for _, grid := range msm.Grid {
+		for _, m := range grid.Maps {
+			if err := os.MkdirAll(filepath.Dir(m.Map.Path()), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(m.Map.Path(), fakePNG(t), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/multistaticmap", bytes.NewReader(mustJSON(msm)))
+
+	// Delete components in a goroutine during the stitch.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		for _, grid := range msm.Grid {
+			for _, m := range grid.Maps {
+				os.Remove(m.Map.Path())
+			}
+		}
+	}()
+
+	mh.Post(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d body=%q", w.Code, w.Body.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+cd rampardos && go test -race ./internal/handlers/ -run TestMultiStaticMapComponentDeletedMidFlight -v
+```
+
+Expected: PASS (components bytes are in memory before the stitch).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rampardos/internal/handlers/static_map_race_test.go
+git commit -m "test(handlers): multi-static map survives component deletion mid-flight"
+```
+
+---
+
+## Task 10: Cleanup — delete dead code and update docs
+
+**Files:**
+- Modify: `rampardos/internal/handlers/static_map.go`
+- Modify: `rampardos/internal/handlers/multi_static_map.go`
+- Modify: `rampardos/internal/services/cache_index.go` (only if a public method becomes unused)
+
+- [ ] **Step 1: Search for dead references to `baseExists` / `HasStaticMap(basePath)`**
+
+```bash
+grep -rn "baseExists\|HasStaticMap(basePath\|AddStaticMap(basePath" rampardos/internal/
+```
+
+Expected: no hits after the refactor. If anything remains, delete it.
+
+- [ ] **Step 2: Verify `ExpiryQueue.Add(..., path, basePath)` is gone**
+
+```bash
+grep -rn "ExpiryQueue.Add.*basePath" rampardos/internal/
+```
+
+Expected: no hits.
+
+- [ ] **Step 3: Run full suite + race**
+
+```bash
+cd rampardos && go test -race ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: remove dead base-existence cache-index paths"
+```
+
+---
+
+## Task 11: Manual smoke test + push
+
+**Files:** none.
+
+- [ ] **Step 1: Build Docker image**
+
+```bash
+docker build -t rampardos:bytes-first .
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 2: Run and hit staticmap with overlays**
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e DEBUG=true \
+  -v $(pwd)/TileServer:/app/TileServer \
+  rampardos:bytes-first &
+
+curl -sS -X POST http://localhost:8080/staticmap \
+  -H 'Content-Type: application/json' \
+  -d '{"latitude":51.5,"longitude":0,"zoom":12,"width":400,"height":400,"style":"klokantech-basic","markers":[{"url":"https://example.com/marker.png","latitude":51.5,"longitude":0}]}' \
+  --output /tmp/smoke.png
+
+file /tmp/smoke.png
+```
+
+Expected: `PNG image data`.
+
+- [ ] **Step 3: Delete base file mid-stream — ensure second request succeeds**
+
+```bash
+# First call populates base
+curl -sS ... > /tmp/first.png
+# Remove the base file (name is deterministic — find in Cache/Static)
+rm "TileServer/.../Cache/Static/<basehash>.png"
+# Second call with different markers → different path, shared basePath
+curl -sS ... > /tmp/second.png
+file /tmp/second.png
+```
+
+Expected: `PNG image data`, no 500.
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git push -u upstream fix-race-bytes-first
+gh pr create --repo lenisko/rampardos --base tileserver-replacement --title "fix: race-free static map generation via bytes-first pipeline" --body "..."
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- ✅ Base read once into `[]byte` → Task 4 Step 2 (`loadOrRenderBaseBytes`).
+- ✅ On ENOENT, render in-memory, best-effort persist → Task 4 Step 2.
+- ✅ Draw overlays onto bytes → Task 2.
+- ✅ Atomic write final → Task 2 (`SaveImageBytes`) called from Task 4.
+- ✅ Multi compose from `[][]byte` → Task 6.
+- ✅ Remove `basePath` from expiry queue → Task 4 Step 8.
+- ✅ Cache index only for final-path hints → Task 4 Step 4.
+- ✅ Survive external deletion of base → Tasks 5, 9.
+- ✅ Per-basePath singleflight for sibling concurrency → Task 4 Step 1.
+- ✅ Serve final bytes from memory (close last race) → Task 4 Step 7.
+- ✅ Markers held in memory through draw (closes CacheCleaner-vs-draw race) → Task 4b.
+- ⚠️ Tile files remain on the disk-read path; mitigated by fresh mtime + `loadImageWithRetry` redownload callback. Out of scope per plan's Scope note.
+
+**Placeholder scan:** No TBDs, no "implement later", no "similar to Task N" references. All code shown inline.
+
+**Type consistency:**
+- `GenerateStaticMapBytes(sm, baseBytes, markerBytes, merc) ([]byte, error)` — signature consistent across Tasks 2, 4, 4b, 7.
+- `downloadMarkerBytes(ctx, sm) (map[string][]byte, error)` — Task 4b; called from `generateStaticMap` in Task 4.
+- `drawOverlays(dc, sm, scale, markerBytes, merc) error` — Task 2 (extracted helper), Task 4b (marker-bytes consumer).
+- `GetMarkerPath` / `GetFallbackMarkerPath` — exported in Task 4b Step 1.
+- `generateStaticMap(ctx, path, basePath, sm, persist) ([]byte, error)` — defined in Task 4, refined in Task 8 (added `persist bool`). Call sites updated in Task 8 Step 1.
+- `GenerateStaticMap(ctx, sm, opts) ([]byte, error)` — Task 4, Task 8. Called by multi handler in Task 7.
+- `ComposeMultiStaticMapBytes(msm, [][]byte) ([]byte, error)` — Task 6; called in Task 7.
+- `SaveImageBytes` — exported in Task 2; called from Task 4, 6, 7.
+- `loadOrRenderBaseBytes(ctx, sm, basePath) ([]byte, error)` — Task 4; called from `generateStaticMap`.
+- `h.baseSfg` — added in Task 4 Step 1; used in `loadOrRenderBaseBytes`.
+
+All consistent.

--- a/rampardos/internal/handlers/common.go
+++ b/rampardos/internal/handlers/common.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/lenisko/rampardos/internal/models"
+	"github.com/lenisko/rampardos/internal/services"
 )
 
 // knownDirs caches directories that have been created to avoid repeated syscalls
@@ -23,49 +23,20 @@ func ensureDir(dir string) {
 	knownDirs.Store(dir, struct{}{})
 }
 
-// atomicWriteFile writes data to a temporary file then renames it to
-// the target path. os.Rename is atomic on POSIX, so readers never see
-// a partially-written file. This prevents corruption when multiple
-// goroutines race to generate the same cached file.
+// atomicWriteFile writes data to path atomically with the requested
+// file mode. Delegates to services.SaveBytesAtomic for the write +
+// rename, then chmods the final path to perm.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	ensureDir(filepath.Dir(path))
-	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp.*")
-	if err != nil {
+	if err := services.SaveBytesAtomic(path, data); err != nil {
 		return err
 	}
-	tmp := f.Name()
-	if _, err := f.Write(data); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return err
-	}
-	f.Close()
-	if err := os.Chmod(tmp, perm); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
+	return os.Chmod(path, perm)
 }
 
 // serveFile serves a file with cache headers
 func serveFile(w http.ResponseWriter, r *http.Request, path string) {
 	w.Header().Set("Cache-Control", "max-age=604800, must-revalidate")
 	http.ServeFile(w, r, path)
-}
-
-func contentTypeFor(format models.ImageFormat) string {
-	switch format {
-	case models.ImageFormatJPG, models.ImageFormatJPEG:
-		return "image/jpeg"
-	case models.ImageFormatWEBP:
-		return "image/webp"
-	default:
-		return "image/png"
-	}
 }
 
 // handlePregenerateResponse handles pregenerate query param and saves regeneratable data if needed.

--- a/rampardos/internal/handlers/common.go
+++ b/rampardos/internal/handlers/common.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/lenisko/rampardos/internal/models"
 )
 
 // knownDirs caches directories that have been created to avoid repeated syscalls
@@ -53,6 +55,17 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 func serveFile(w http.ResponseWriter, r *http.Request, path string) {
 	w.Header().Set("Cache-Control", "max-age=604800, must-revalidate")
 	http.ServeFile(w, r, path)
+}
+
+func contentTypeFor(format models.ImageFormat) string {
+	switch format {
+	case models.ImageFormatJPG, models.ImageFormatJPEG:
+		return "image/jpeg"
+	case models.ImageFormatWEBP:
+		return "image/webp"
+	default:
+		return "image/png"
+	}
 }
 
 // handlePregenerateResponse handles pregenerate query param and saves regeneratable data if needed.

--- a/rampardos/internal/handlers/marker_bytes_test.go
+++ b/rampardos/internal/handlers/marker_bytes_test.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/lenisko/rampardos/internal/models"
+	"github.com/lenisko/rampardos/internal/utils"
+)
+
+// TestMarkerDeletedBetweenDownloadAndDrawDoesNotFail verifies that
+// marker bytes held in memory survive external deletion of the
+// Cache/Marker file. Before Task 4b, drawOverlays read markers from
+// disk and would fail here.
+func TestMarkerDeletedBetweenDownloadAndDrawDoesNotFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(fakePNG(t))
+	}))
+	defer srv.Close()
+
+	h, cleanup := newTestStaticMapHandler(t)
+	defer cleanup()
+
+	sm := models.StaticMap{
+		Markers: []models.Marker{{URL: srv.URL + "/a.png", Latitude: 0, Longitude: 0}},
+	}
+
+	markers, err := h.downloadMarkerBytes(context.Background(), sm)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	key := utils.GetMarkerPath(sm.Markers[0])
+	if len(markers[key]) == 0 {
+		t.Fatalf("expected bytes at %s; got %v", key, markers)
+	}
+
+	// Simulate CacheCleaner deleting the on-disk marker mid-request.
+	_ = os.Remove(key)
+
+	// Render must still succeed because markers are in memory.
+	baseBytes := fakePNG(t)
+	merc := utils.NewSphericalMercator()
+	sm.Width, sm.Height = 16, 16
+	sm.Zoom = 10
+	if _, err := utils.GenerateStaticMapBytes(sm, baseBytes, markers, merc); err != nil {
+		t.Fatalf("render after marker deletion: %v", err)
+	}
+}

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -197,7 +197,7 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 				sem <- struct{}{}
 				defer func() { <-sem }()
 
-				if err := h.staticMapHandler.GenerateStaticMap(r.Context(), sm, componentOpts); err != nil {
+				if _, err := h.staticMapHandler.GenerateStaticMap(r.Context(), sm, componentOpts); err != nil {
 					errOnce.Do(func() {
 						genErr = err
 					})

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -306,7 +306,7 @@ func (h *MultiStaticMapHandler) generateResponseBytes(w http.ResponseWriter, r *
 		return
 	}
 	if stitched != nil {
-		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Type", models.ImageFormatPNG.ContentType())
 		w.Header().Set("Content-Length", strconv.Itoa(len(stitched)))
 		_, _ = w.Write(stitched)
 		return

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -157,75 +157,66 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Collect all maps to generate
-	var mapsToGenerate []models.StaticMap
+	// Flatten component order for the stitcher.
+	var components []models.StaticMap
 	for _, grid := range multiStaticMap.Grid {
 		for _, m := range grid.Maps {
-			mapsToGenerate = append(mapsToGenerate, m.Map)
+			components = append(components, m.Map)
 		}
 	}
-	mapCount := len(mapsToGenerate)
+	mapCount := len(components)
 
 	// Flow through nocache/ttl to component map generation.
-	componentOpts := GenerateOpts{}
-	if skipCache {
-		componentOpts.NoCache = true
-	}
+	componentOpts := GenerateOpts{NoCache: skipCache}
 	if ttlSeconds > 0 {
 		componentOpts.TTL = time.Duration(ttlSeconds) * time.Second
 	}
 
 	// singleflight: deduplicate the entire generate+combine operation
-	// for identical multistaticmap requests.
-	_, sfErr, _ := h.sfg.Do(path, func() (any, error) {
+	// for identical multistaticmap requests. Returns the final stitched
+	// bytes so the caller can serve from memory.
+	v, sfErr, _ := h.sfg.Do(path, func() (any, error) {
 		if !skipCache {
-			if _, err := os.Stat(path); err == nil {
-				return nil, nil
+			if b, err := os.ReadFile(path); err == nil {
+				return b, nil
 			}
 		}
 
-		// Generate all component maps in parallel (limit concurrency to 5)
-		var wg sync.WaitGroup
-		var genErr error
-		var errOnce sync.Once
+		// Parallel component generation, preserving slot order for the stitcher.
+		componentBytes := make([][]byte, len(components))
+		errCh := make(chan error, len(components))
 		sem := make(chan struct{}, 5)
-
-		for _, staticMap := range mapsToGenerate {
+		var wg sync.WaitGroup
+		for i, sm := range components {
 			wg.Add(1)
-			go func(sm models.StaticMap) {
+			sem <- struct{}{}
+			go func(i int, sm models.StaticMap) {
 				defer wg.Done()
-				sem <- struct{}{}
 				defer func() { <-sem }()
-
-				if _, err := h.staticMapHandler.GenerateStaticMap(r.Context(), sm, componentOpts); err != nil {
-					errOnce.Do(func() {
-						genErr = err
-					})
+				b, err := h.staticMapHandler.GenerateStaticMap(r.Context(), sm, componentOpts)
+				if err != nil {
+					errCh <- err
+					return
 				}
-			}(staticMap)
+				componentBytes[i] = b
+			}(i, sm)
 		}
 		wg.Wait()
-
-		if genErr != nil {
-			return nil, genErr
+		close(errCh)
+		if err, ok := <-errCh; ok {
+			return nil, err
 		}
 
-		ensureDir(filepath.Dir(path))
-		err := utils.GenerateMultiStaticMap(multiStaticMap, path)
-
-		// For nocache, clean up component files now that they've been
-		// combined into the final image.
-		if skipCache {
-			for _, sm := range mapsToGenerate {
-				os.Remove(sm.Path())
-				bp := sm.BasePath()
-				if bp != sm.Path() {
-					os.Remove(bp)
-				}
+		stitched, err := utils.ComposeMultiStaticMapBytes(multiStaticMap, componentBytes)
+		if err != nil {
+			return nil, err
+		}
+		if !skipCache {
+			if err := utils.SaveImageBytes(path, stitched); err != nil {
+				return nil, err
 			}
 		}
-
-		return nil, err
+		return stitched, nil
 	})
 
 	if sfErr != nil {
@@ -235,14 +226,19 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	var stitched []byte
+	if v != nil {
+		stitched, _ = v.([]byte)
+	}
+
 	duration := time.Since(startTime).Seconds()
 	h.statsController.StaticMapServed(true, path, "multi")
 	services.GlobalMetrics.RecordRequest("multistaticmap", "multi", false, duration)
 
 	if skipCache {
+		// nocache: serve bytes directly, no disk footprint.
 		slog.Debug("Served multi-static map (nocache)", "file", filepath.Base(path), "maps", mapCount, "duration", duration)
-		serveFile(w, r, path)
-		os.Remove(path)
+		h.generateResponseBytes(w, r, multiStaticMap, path, stitched)
 		return
 	}
 
@@ -250,7 +246,7 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		services.GlobalCacheIndex.AddMultiStaticMap(path)
 	}
 	slog.Debug("Served multi-static map (generated)", "file", filepath.Base(path), "maps", mapCount, "duration", duration, "ttl", ttlSeconds)
-	h.generateResponse(w, r, multiStaticMap, path)
+	h.generateResponseBytes(w, r, multiStaticMap, path, stitched)
 
 	if ttlSeconds > 0 && services.GlobalExpiryQueue != nil {
 		cleanupIndex := func() {
@@ -297,6 +293,22 @@ func (h *MultiStaticMapHandler) handlePregeneratedRequest(w http.ResponseWriter,
 
 func (h *MultiStaticMapHandler) generateResponse(w http.ResponseWriter, r *http.Request, multiStaticMap models.MultiStaticMap, path string) {
 	if handlePregenerateResponse(w, r, path, multiStaticMap) {
+		return
+	}
+	serveFile(w, r, path)
+}
+
+// generateResponseBytes prefers serving the stitched bytes in memory
+// so the response is immune to external deletion of path between the
+// atomic-write and serve. Falls back to serveFile if stitched is nil.
+func (h *MultiStaticMapHandler) generateResponseBytes(w http.ResponseWriter, r *http.Request, msm models.MultiStaticMap, path string, stitched []byte) {
+	if handlePregenerateResponse(w, r, path, msm) {
+		return
+	}
+	if stitched != nil {
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Length", strconv.Itoa(len(stitched)))
+		_, _ = w.Write(stitched)
 		return
 	}
 	serveFile(w, r, path)

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -625,9 +625,6 @@ func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap mo
 		}
 		// Remote marker. Cached on disk?
 		if b, err := os.ReadFile(key); err == nil {
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.AddMarker(key)
-			}
 			if h.statsController != nil {
 				h.statsController.MarkerServed(false, key, extractDomain(marker.URL))
 			}
@@ -657,9 +654,6 @@ func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap mo
 
 			b, err := services.DownloadBytes(ctx, w.marker.URL, w.key, "", 0)
 			if err == nil {
-				if services.GlobalCacheIndex != nil {
-					services.GlobalCacheIndex.AddMarker(w.key)
-				}
 				if h.statsController != nil {
 					h.statsController.MarkerServed(true, w.key, extractDomain(w.marker.URL))
 				}
@@ -675,9 +669,6 @@ func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap mo
 			fbKey := utils.GetFallbackMarkerPath(w.marker)
 			fbDomain := extractDomain(w.marker.FallbackURL)
 			if fb, err := os.ReadFile(fbKey); err == nil {
-				if services.GlobalCacheIndex != nil {
-					services.GlobalCacheIndex.AddMarker(fbKey)
-				}
 				if h.statsController != nil {
 					h.statsController.MarkerServed(false, fbKey, fbDomain)
 				}
@@ -691,9 +682,6 @@ func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap mo
 				slog.Warn("Marker primary and fallback both failed; omitting from image",
 					"url", w.marker.URL, "fallback", w.marker.FallbackURL, "error", fbErr)
 				return
-			}
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.AddMarker(fbKey)
 			}
 			if h.statsController != nil {
 				h.statsController.MarkerServed(true, fbKey, fbDomain)

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -365,13 +365,12 @@ func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath
 		return baseBytes, nil
 	}
 
-	if err := h.downloadMarkers(ctx, staticMap); err != nil {
+	markerBytes, err := h.downloadMarkerBytes(ctx, staticMap)
+	if err != nil {
 		return nil, err
 	}
 
-	// markerBytes is nil here — drawOverlays falls back to disk reads
-	// for markers. Task 4b will upgrade this to in-memory markers.
-	finalBytes, err := utils.GenerateStaticMapBytes(staticMap, baseBytes, nil, h.sphericalMercator)
+	finalBytes, err := utils.GenerateStaticMapBytes(staticMap, baseBytes, markerBytes, h.sphericalMercator)
 	if err != nil {
 		return nil, err
 	}
@@ -572,105 +571,130 @@ func (h *StaticMapHandler) generateBaseStaticMapFromTiles(ctx context.Context, s
 	return utils.ComposeBaseStaticMapBytes(staticMap, tilePaths, offsetX, offsetY, hasScale, redownload)
 }
 
-func (h *StaticMapHandler) downloadMarkers(ctx context.Context, staticMap models.StaticMap) error {
-	// Ensure marker cache directory exists
+// downloadMarkerBytes returns marker image bytes keyed by each
+// marker's cache path (utils.GetMarkerPath). Bytes are read once
+// per request — either from disk when the marker is cached, or
+// directly from the HTTP response (and best-effort persisted to
+// Cache/Marker). Callers pass the map to utils.GenerateStaticMapBytes
+// so the overlay draw never touches Cache/Marker disk — closing the
+// race between CacheCleaner and draw that the old downloadMarkers
+// (which only wrote to disk) could not close.
+//
+// Primary URL failures fall back to marker.FallbackURL when present;
+// the fallback's bytes are stored under the PRIMARY key so
+// drawOverlays' map lookup still succeeds.
+func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap models.StaticMap) (map[string][]byte, error) {
 	ensureDir("Cache/Marker")
-
-	// Collect markers that need downloading
-	type markerDownload struct {
-		marker models.Marker
-		path   string
-		domain string
-		format string
+	if len(staticMap.Markers) == 0 {
+		return nil, nil
 	}
-	var toDownload []markerDownload
+
+	result := make(map[string][]byte, len(staticMap.Markers))
+	var mu sync.Mutex
+
+	type work struct {
+		marker models.Marker
+		key    string // primary key (always utils.GetMarkerPath)
+	}
+	var toFetch []work
 
 	for _, marker := range staticMap.Markers {
+		key := utils.GetMarkerPath(marker)
 		if !strings.HasPrefix(marker.URL, "http://") && !strings.HasPrefix(marker.URL, "https://") {
-			continue
-		}
-
-		hash := utils.PersistentHashString(marker.URL)
-		parts := strings.Split(marker.URL, ".")
-		format := "png"
-		if len(parts) > 0 {
-			format = parts[len(parts)-1]
-		}
-		path := fmt.Sprintf("Cache/Marker/%s.%s", hash, format)
-		domain := extractDomain(marker.URL)
-
-		// Check cache index first (fast path)
-		if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasMarker(path) {
-			h.statsController.MarkerServed(false, path, domain)
-			continue
-		}
-
-		// Check filesystem
-		if _, err := os.Stat(path); err == nil {
-			// Add to cache index
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.AddMarker(path)
+			// Bundled marker under Markers/ — read directly once.
+			b, err := os.ReadFile(key)
+			if err != nil {
+				return nil, fmt.Errorf("read bundled marker %s: %w", key, err)
 			}
-			h.statsController.MarkerServed(false, path, domain)
+			result[key] = b
 			continue
 		}
-
-		toDownload = append(toDownload, markerDownload{marker, path, domain, format})
+		// Remote marker. Cached on disk?
+		if b, err := os.ReadFile(key); err == nil {
+			if services.GlobalCacheIndex != nil {
+				services.GlobalCacheIndex.AddMarker(key)
+			}
+			if h.statsController != nil {
+				h.statsController.MarkerServed(false, key, extractDomain(marker.URL))
+			}
+			result[key] = b
+			continue
+		}
+		toFetch = append(toFetch, work{marker: marker, key: key})
 	}
 
-	if len(toDownload) == 0 {
-		return nil
+	if len(toFetch) == 0 {
+		return result, nil
 	}
 
-	// Download markers in parallel (limit concurrency to 10)
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 10)
+	var fetchErr error
+	var errOnce sync.Once
 
-	for _, md := range toDownload {
+	for _, w := range toFetch {
 		wg.Add(1)
-		go func(md markerDownload) {
+		go func(w work) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			if err := services.DownloadFile(ctx, md.marker.URL, md.path, "", 0); err != nil {
-				// Try fallback
-				if md.marker.FallbackURL != "" {
-					fallbackHash := utils.PersistentHashString(md.marker.FallbackURL)
-					fallbackPath := fmt.Sprintf("Cache/Marker/%s.%s", fallbackHash, md.format)
-					fallbackDomain := extractDomain(md.marker.FallbackURL)
-
-					// Check if fallback exists
-					if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasMarker(fallbackPath) {
-						h.statsController.MarkerServed(false, fallbackPath, fallbackDomain)
-						return
-					}
-					if _, err := os.Stat(fallbackPath); err == nil {
-						if services.GlobalCacheIndex != nil {
-							services.GlobalCacheIndex.AddMarker(fallbackPath)
-						}
-						h.statsController.MarkerServed(false, fallbackPath, fallbackDomain)
-						return
-					}
-
-					if err := services.DownloadFile(ctx, md.marker.FallbackURL, fallbackPath, "", 0); err == nil {
-						if services.GlobalCacheIndex != nil {
-							services.GlobalCacheIndex.AddMarker(fallbackPath)
-						}
-						h.statsController.MarkerServed(true, fallbackPath, fallbackDomain)
-					}
-				}
-			} else {
+			b, err := services.DownloadBytes(ctx, w.marker.URL, w.key, "", 0)
+			if err == nil {
 				if services.GlobalCacheIndex != nil {
-					services.GlobalCacheIndex.AddMarker(md.path)
+					services.GlobalCacheIndex.AddMarker(w.key)
 				}
-				h.statsController.MarkerServed(true, md.path, md.domain)
+				if h.statsController != nil {
+					h.statsController.MarkerServed(true, w.key, extractDomain(w.marker.URL))
+				}
+				mu.Lock()
+				result[w.key] = b
+				mu.Unlock()
+				return
 			}
-		}(md)
+			if w.marker.FallbackURL == "" {
+				errOnce.Do(func() { fetchErr = fmt.Errorf("marker %s: %w", w.marker.URL, err) })
+				return
+			}
+			fbKey := utils.GetFallbackMarkerPath(w.marker)
+			fbDomain := extractDomain(w.marker.FallbackURL)
+			// Cached fallback on disk?
+			if fb, err := os.ReadFile(fbKey); err == nil {
+				if services.GlobalCacheIndex != nil {
+					services.GlobalCacheIndex.AddMarker(fbKey)
+				}
+				if h.statsController != nil {
+					h.statsController.MarkerServed(false, fbKey, fbDomain)
+				}
+				mu.Lock()
+				result[w.key] = fb // stored under PRIMARY key for drawOverlays lookup
+				mu.Unlock()
+				return
+			}
+			fb, fbErr := services.DownloadBytes(ctx, w.marker.FallbackURL, fbKey, "", 0)
+			if fbErr != nil {
+				errOnce.Do(func() {
+					fetchErr = fmt.Errorf("marker %s (both primary and fallback failed): %w", w.marker.URL, fbErr)
+				})
+				return
+			}
+			if services.GlobalCacheIndex != nil {
+				services.GlobalCacheIndex.AddMarker(fbKey)
+			}
+			if h.statsController != nil {
+				h.statsController.MarkerServed(true, fbKey, fbDomain)
+			}
+			mu.Lock()
+			result[w.key] = fb
+			mu.Unlock()
+		}(w)
 	}
-
 	wg.Wait()
-	return nil
+
+	if fetchErr != nil {
+		return nil, fetchErr
+	}
+	return result, nil
 }
 
 func extractDomain(url string) string {

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -36,7 +37,8 @@ type StaticMapHandler struct {
 	statsController   *services.StatsController
 	stylesController  stylesControllerGetExternal
 	sphericalMercator *utils.SphericalMercator
-	sfg               singleflight.Group // dedup concurrent generates for same path
+	sfg     singleflight.Group // dedupe concurrent generates for same final path
+	baseSfg singleflight.Group // dedupe concurrent base renders for same basePath
 
 	// Function-valued hooks. Production wiring in NewStaticMapHandler
 	// sets these to the real methods below; tests override them to
@@ -142,54 +144,43 @@ type GenerateOpts struct {
 	TTL        time.Duration // if > 0, queue files for deletion after this duration
 }
 
-// GenerateStaticMap generates a static map (used by MultiStaticMapHandler).
-// Concurrent requests for the same map are deduplicated via singleflight.
-func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap models.StaticMap, opts GenerateOpts) error {
+// GenerateStaticMap produces the final static map bytes for a
+// component request from the multi-map handler. When opts.NoCache
+// is true, nothing is persisted to disk. When opts.TTL > 0, the
+// final path is scheduled for deletion; basePath is NOT enqueued
+// (it's shared state governed by CacheCleaner).
+func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap models.StaticMap, opts GenerateOpts) ([]byte, error) {
 	path := staticMap.Path()
 	basePath := staticMap.BasePath()
 
 	if !opts.NoCache {
-		if _, err := os.Stat(path); err == nil {
-			return nil
+		if b, err := os.ReadFile(path); err == nil {
+			return b, nil
 		}
 	}
 
-	_, err, _ := h.sfg.Do(path, func() (any, error) {
+	v, err, _ := h.sfg.Do(path, func() (any, error) {
 		if !opts.NoCache {
-			if _, err := os.Stat(path); err == nil {
-				return nil, nil
+			if b, err := os.ReadFile(path); err == nil {
+				return b, nil
 			}
 		}
-		baseExists := false
-		if _, err := os.Stat(basePath); err == nil {
-			baseExists = true
-		}
-		return nil, h.generateStaticMap(ctx, path, basePath, baseExists, staticMap)
+		return h.generateStaticMap(ctx, path, basePath, staticMap, !opts.NoCache)
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
+	finalBytes, _ := v.([]byte)
 
-	// Apply TTL or nocache cleanup to component files.
-	if opts.NoCache {
-		// Caller will read the file then we clean up.
-		// Defer cleanup so the multistaticmap combiner can read it first.
-		// The caller (multistaticmap handler) is responsible for calling
-		// CleanupComponentMaps after combining.
-	} else if opts.TTL > 0 && services.GlobalExpiryQueue != nil {
+	if !opts.NoCache && opts.TTL > 0 && services.GlobalExpiryQueue != nil {
 		cleanupIndex := func() {
 			if services.GlobalCacheIndex != nil {
 				services.GlobalCacheIndex.RemoveStaticMap(path)
 			}
 		}
-		if path != basePath {
-			services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path, basePath)
-		} else {
-			services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path)
-		}
+		services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path)
 	}
-
-	return nil
+	return finalBytes, nil
 }
 
 func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request, staticMap models.StaticMap) {
@@ -263,23 +254,18 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 	// Deduplicate concurrent requests for the same static map via
 	// singleflight. Two poracle webhooks for the same spawn arriving
 	// simultaneously will only generate once.
-	_, genErr, _ := h.sfg.Do(path, func() (any, error) {
+	v, genErr, _ := h.sfg.Do(path, func() (any, error) {
 		// Double-check cache inside singleflight.
-		if _, err := os.Stat(path); err == nil {
-			return nil, nil
+		if b, err := os.ReadFile(path); err == nil {
+			return b, nil
 		}
-
-		baseExists := false
-		if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasStaticMap(basePath) {
-			baseExists = true
-		} else if _, err := os.Stat(basePath); err == nil {
-			baseExists = true
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.AddStaticMap(basePath)
-			}
-		}
-		return nil, h.generateStaticMap(r.Context(), path, basePath, baseExists, staticMap)
+		return h.generateStaticMap(r.Context(), path, basePath, staticMap, true)
 	})
+
+	var finalBytes []byte
+	if genErr == nil && v != nil {
+		finalBytes, _ = v.([]byte)
+	}
 
 	if genErr != nil {
 		slog.Error("Failed to generate static map", "error", genErr)
@@ -297,7 +283,7 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 		// files. No cache index entry, no disk footprint left behind.
 		// (pregenerate+nocache is already converted to TTL above.)
 		slog.Debug("Served static map (nocache)", "file", filepath.Base(path), "duration", duration)
-		serveFile(w, r, path)
+		h.generateResponseBytes(w, r, staticMap, path, finalBytes)
 		os.Remove(path)
 		if path != basePath {
 			os.Remove(basePath)
@@ -310,7 +296,7 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 		services.GlobalCacheIndex.AddStaticMap(path)
 	}
 	slog.Debug("Served static map (generated)", "file", filepath.Base(path), "duration", duration, "ttl", ttlSeconds)
-	h.generateResponse(w, r, staticMap, path)
+	h.generateResponseBytes(w, r, staticMap, path, finalBytes)
 
 	// If a TTL was requested, queue the file for deletion after the
 	// specified duration. A single background sweeper handles cleanup.
@@ -321,11 +307,7 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 				services.GlobalCacheIndex.RemoveStaticMap(path)
 			}
 		}
-		if path != basePath {
-			services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path, basePath)
-		} else {
-			services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
-		}
+		services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
 	}
 }
 
@@ -362,43 +344,74 @@ func (h *StaticMapHandler) handlePregeneratedRequest(w http.ResponseWriter, r *h
 	h.handleRequest(w, r, staticMap)
 }
 
-func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath string, baseExists bool, staticMap models.StaticMap) error {
-	// Ensure cache directory exists (cached check)
-	ensureDir(filepath.Dir(path))
-
+// generateStaticMap produces the final static map bytes. When
+// persist is true, the bytes are also written atomically to path.
+// Returns the final bytes so callers can serve directly from memory,
+// closing the TOCTOU window between atomic-write and http.ServeFile.
+func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath string, staticMap models.StaticMap, persist bool) ([]byte, error) {
 	hasDrawables := len(staticMap.Markers) > 0 || len(staticMap.Polygons) > 0 || len(staticMap.Circles) > 0
 
-	// Generate base if needed
-	if !baseExists {
-		baseBytes, err := h.generateBaseStaticMap(ctx, staticMap)
-		if err != nil {
-			return err
-		}
-		if err := utils.SaveImageBytes(basePath, baseBytes); err != nil {
-			return err
-		}
+	baseBytes, err := h.loadOrRenderBaseBytes(ctx, staticMap, basePath)
+	if err != nil {
+		return nil, err
 	}
 
-	// If no drawables, just use base
 	if !hasDrawables {
-		// Copy or link base to path
-		if path != basePath {
-			data, err := os.ReadFile(basePath)
-			if err != nil {
-				return err
+		if persist && path != basePath {
+			if err := utils.SaveImageBytes(path, baseBytes); err != nil {
+				return nil, err
 			}
-			return atomicWriteFile(path, data, 0644)
 		}
-		return nil
+		return baseBytes, nil
 	}
 
-	// Download markers if needed
 	if err := h.downloadMarkers(ctx, staticMap); err != nil {
-		return err
+		return nil, err
 	}
 
-	// Generate with drawables
-	return utils.GenerateStaticMap(staticMap, basePath, path, h.sphericalMercator)
+	// markerBytes is nil here — drawOverlays falls back to disk reads
+	// for markers. Task 4b will upgrade this to in-memory markers.
+	finalBytes, err := utils.GenerateStaticMapBytes(staticMap, baseBytes, nil, h.sphericalMercator)
+	if err != nil {
+		return nil, err
+	}
+	if persist {
+		if err := utils.SaveImageBytes(path, finalBytes); err != nil {
+			return nil, err
+		}
+	}
+	return finalBytes, nil
+}
+
+// loadOrRenderBaseBytes returns the base image bytes for staticMap.
+// Reads basePath from disk if present; on ENOENT, renders the base
+// in-memory and best-effort persists it to basePath. Concurrent
+// callers for the same basePath are deduplicated, so sibling
+// requests (different overlays, same viewport) do not duplicate
+// base rendering.
+//
+// Cache-persist failure is non-fatal: the request succeeds with
+// bytes in hand; the next request pays the cache miss.
+func (h *StaticMapHandler) loadOrRenderBaseBytes(ctx context.Context, staticMap models.StaticMap, basePath string) ([]byte, error) {
+	v, err, _ := h.baseSfg.Do(basePath, func() (any, error) {
+		if b, err := os.ReadFile(basePath); err == nil {
+			return b, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("read base: %w", err)
+		}
+		b, err := h.generateBaseStaticMap(ctx, staticMap)
+		if err != nil {
+			return nil, err
+		}
+		if writeErr := utils.SaveImageBytes(basePath, b); writeErr != nil {
+			slog.Warn("Failed to cache base image", "path", basePath, "error", writeErr)
+		}
+		return b, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.([]byte), nil
 }
 
 func (h *StaticMapHandler) generateBaseStaticMap(ctx context.Context, staticMap models.StaticMap) ([]byte, error) {
@@ -675,6 +688,23 @@ func extractDomain(url string) string {
 
 func (h *StaticMapHandler) generateResponse(w http.ResponseWriter, r *http.Request, staticMap models.StaticMap, path string) {
 	if handlePregenerateResponse(w, r, path, staticMap) {
+		return
+	}
+	serveFile(w, r, path)
+}
+
+// generateResponseBytes prefers the in-memory bytes so the response
+// is immune to external deletion of path between the atomic-write
+// and the serve. Falls back to serving from disk if finalBytes is
+// nil (e.g. the fast-path cached-hit branch before this block).
+func (h *StaticMapHandler) generateResponseBytes(w http.ResponseWriter, r *http.Request, staticMap models.StaticMap, path string, finalBytes []byte) {
+	if handlePregenerateResponse(w, r, path, staticMap) {
+		return
+	}
+	if finalBytes != nil {
+		w.Header().Set("Content-Type", contentTypeFor(staticMap.GetFormat()))
+		w.Header().Set("Content-Length", strconv.Itoa(len(finalBytes)))
+		_, _ = w.Write(finalBytes)
 		return
 	}
 	serveFile(w, r, path)

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -41,8 +41,8 @@ type StaticMapHandler struct {
 	// Function-valued hooks. Production wiring in NewStaticMapHandler
 	// sets these to the real methods below; tests override them to
 	// record dispatch without touching tileserver-gl or disk.
-	generateBaseStaticMapFromAPIFn   func(ctx context.Context, sm models.StaticMap, basePath string) error
-	generateBaseStaticMapFromTilesFn func(ctx context.Context, sm models.StaticMap, basePath string, extStyle *models.Style) error
+	generateBaseStaticMapFromAPIFn   func(ctx context.Context, sm models.StaticMap) ([]byte, error)
+	generateBaseStaticMapFromTilesFn func(ctx context.Context, sm models.StaticMap, extStyle *models.Style) ([]byte, error)
 	logExternalViewportApproxFn      func(sm models.StaticMap)
 }
 
@@ -370,7 +370,11 @@ func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath
 
 	// Generate base if needed
 	if !baseExists {
-		if err := h.generateBaseStaticMap(ctx, staticMap, basePath); err != nil {
+		baseBytes, err := h.generateBaseStaticMap(ctx, staticMap)
+		if err != nil {
+			return err
+		}
+		if err := utils.SaveImageBytes(basePath, baseBytes); err != nil {
 			return err
 		}
 	}
@@ -397,23 +401,20 @@ func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath
 	return utils.GenerateStaticMap(staticMap, basePath, path, h.sphericalMercator)
 }
 
-func (h *StaticMapHandler) generateBaseStaticMap(ctx context.Context, staticMap models.StaticMap, basePath string) error {
-	extStyle := h.stylesController.GetExternalStyle(staticMap.Style) // nil for local styles
+func (h *StaticMapHandler) generateBaseStaticMap(ctx context.Context, staticMap models.StaticMap) ([]byte, error) {
+	extStyle := h.stylesController.GetExternalStyle(staticMap.Style)
 
 	if extStyle == nil {
-		// Local style: fractional zoom → viewport render (native float zoom).
-		// Integer zoom → tile stitching (cacheable via Cache/Tile).
 		if isFractional(staticMap.Zoom) {
-			return h.generateBaseStaticMapFromAPIFn(ctx, staticMap, basePath)
+			return h.generateBaseStaticMapFromAPIFn(ctx, staticMap)
 		}
-		return h.generateBaseStaticMapFromTilesFn(ctx, staticMap, basePath, extStyle)
+		return h.generateBaseStaticMapFromTilesFn(ctx, staticMap, extStyle)
 	}
 
-	// External styles: tile stitching (no viewport endpoint available).
 	if isFractional(staticMap.Zoom) {
 		h.logExternalViewportApproxFn(staticMap)
 	}
-	return h.generateBaseStaticMapFromTilesFn(ctx, staticMap, basePath, extStyle)
+	return h.generateBaseStaticMapFromTilesFn(ctx, staticMap, extStyle)
 }
 
 func (h *StaticMapHandler) logExternalViewportApprox(sm models.StaticMap) {
@@ -425,12 +426,11 @@ func (h *StaticMapHandler) logExternalViewportApprox(sm models.StaticMap) {
 	)
 }
 
-func (h *StaticMapHandler) generateBaseStaticMapFromAPI(ctx context.Context, staticMap models.StaticMap, basePath string) error {
+func (h *StaticMapHandler) generateBaseStaticMapFromAPI(ctx context.Context, staticMap models.StaticMap) ([]byte, error) {
 	scale := staticMap.Scale
 	if scale == 0 {
 		scale = 1
 	}
-
 	bearing := 0.0
 	if staticMap.Bearing != nil {
 		bearing = *staticMap.Bearing
@@ -439,7 +439,6 @@ func (h *StaticMapHandler) generateBaseStaticMapFromAPI(ctx context.Context, sta
 	if staticMap.Pitch != nil {
 		pitch = *staticMap.Pitch
 	}
-
 	encoded, err := h.renderer.RenderViewport(ctx, renderer.ViewportRequest{
 		StyleID:   staticMap.Style,
 		Longitude: staticMap.Longitude,
@@ -453,17 +452,12 @@ func (h *StaticMapHandler) generateBaseStaticMapFromAPI(ctx context.Context, sta
 		Format:    staticMap.GetFormat(),
 	})
 	if err != nil {
-		return fmt.Errorf("renderer viewport: %w", err)
+		return nil, fmt.Errorf("renderer viewport: %w", err)
 	}
-
-	ensureDir(filepath.Dir(basePath))
-	if err := atomicWriteFile(basePath, encoded, 0o644); err != nil {
-		return fmt.Errorf("write base path: %w", err)
-	}
-	return nil
+	return encoded, nil
 }
 
-func (h *StaticMapHandler) generateBaseStaticMapFromTiles(ctx context.Context, staticMap models.StaticMap, basePath string, extStyle *models.Style) error {
+func (h *StaticMapHandler) generateBaseStaticMapFromTiles(ctx context.Context, staticMap models.StaticMap, extStyle *models.Style) ([]byte, error) {
 	// Calculate tiles needed
 	center := models.Coordinate{Latitude: staticMap.Latitude, Longitude: staticMap.Longitude}
 	zoom := int(staticMap.Zoom)
@@ -528,7 +522,7 @@ func (h *StaticMapHandler) generateBaseStaticMapFromTiles(ctx context.Context, s
 	for range totalTiles {
 		slot := <-results
 		if slot.err != nil {
-			return fmt.Errorf("failed to generate tile: %w", slot.err)
+			return nil, fmt.Errorf("failed to generate tile: %w", slot.err)
 		}
 		tilePaths[slot.index] = slot.path
 	}
@@ -562,7 +556,7 @@ func (h *StaticMapHandler) generateBaseStaticMapFromTiles(ctx context.Context, s
 	}
 
 	// Combine tiles
-	return utils.GenerateBaseStaticMap(staticMap, tilePaths, basePath, offsetX, offsetY, hasScale, redownload)
+	return utils.ComposeBaseStaticMapBytes(staticMap, tilePaths, offsetX, offsetY, hasScale, redownload)
 }
 
 func (h *StaticMapHandler) downloadMarkers(ctx context.Context, staticMap models.StaticMap) error {

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -726,7 +726,7 @@ func (h *StaticMapHandler) generateResponseBytes(w http.ResponseWriter, r *http.
 		return
 	}
 	if finalBytes != nil {
-		w.Header().Set("Content-Type", contentTypeFor(staticMap.GetFormat()))
+		w.Header().Set("Content-Type", staticMap.GetFormat().ContentType())
 		w.Header().Set("Content-Length", strconv.Itoa(len(finalBytes)))
 		_, _ = w.Write(finalBytes)
 		return

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -389,6 +389,12 @@ func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath
 // requests (different overlays, same viewport) do not duplicate
 // base rendering.
 //
+// Singleflight key correctness: basePath == BasePath() ==
+// hash(WithoutDrawables()), so two callers share a slot iff their
+// base-rendering inputs (style/lat/lon/zoom/w/h/scale/bearing/pitch/
+// format) are identical. generateBaseStaticMap reads none of
+// Markers/Polygons/Circles, so merging the renders is safe.
+//
 // Cache-persist failure is non-fatal: the request succeeds with
 // bytes in hand; the next request pays the cache miss.
 func (h *StaticMapHandler) loadOrRenderBaseBytes(ctx context.Context, staticMap models.StaticMap, basePath string) ([]byte, error) {
@@ -582,7 +588,15 @@ func (h *StaticMapHandler) generateBaseStaticMapFromTiles(ctx context.Context, s
 //
 // Primary URL failures fall back to marker.FallbackURL when present;
 // the fallback's bytes are stored under the PRIMARY key so
-// drawOverlays' map lookup still succeeds.
+// drawOverlays' map lookup still succeeds. This is load-bearing:
+// drawOverlays does `markerBytes[GetMarkerPath(marker)]` with no
+// awareness of fallback. If that lookup moves, the fallback store
+// key here must move in lockstep.
+//
+// Marker download failure is non-fatal: the key is omitted from
+// the result map, drawOverlays skips missing markers, and the
+// request renders without it. Matches the legacy downloadMarkers
+// behaviour — a broken marker URL must not 500 a staticmap request.
 func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap models.StaticMap) (map[string][]byte, error) {
 	ensureDir("Cache/Marker")
 	if len(staticMap.Markers) == 0 {
@@ -627,10 +641,12 @@ func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap mo
 		return result, nil
 	}
 
+	// Marker failures are tolerated: a missing marker is omitted from
+	// the result map, drawOverlays skips it, and the request still
+	// succeeds. This matches the legacy downloadMarkers behaviour —
+	// a broken marker URL should not 500 a staticmap request.
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 10)
-	var fetchErr error
-	var errOnce sync.Once
 
 	for _, w := range toFetch {
 		wg.Add(1)
@@ -653,12 +669,11 @@ func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap mo
 				return
 			}
 			if w.marker.FallbackURL == "" {
-				errOnce.Do(func() { fetchErr = fmt.Errorf("marker %s: %w", w.marker.URL, err) })
+				slog.Warn("Marker download failed; omitting from image", "url", w.marker.URL, "error", err)
 				return
 			}
 			fbKey := utils.GetFallbackMarkerPath(w.marker)
 			fbDomain := extractDomain(w.marker.FallbackURL)
-			// Cached fallback on disk?
 			if fb, err := os.ReadFile(fbKey); err == nil {
 				if services.GlobalCacheIndex != nil {
 					services.GlobalCacheIndex.AddMarker(fbKey)
@@ -673,9 +688,8 @@ func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap mo
 			}
 			fb, fbErr := services.DownloadBytes(ctx, w.marker.FallbackURL, fbKey, "", 0)
 			if fbErr != nil {
-				errOnce.Do(func() {
-					fetchErr = fmt.Errorf("marker %s (both primary and fallback failed): %w", w.marker.URL, fbErr)
-				})
+				slog.Warn("Marker primary and fallback both failed; omitting from image",
+					"url", w.marker.URL, "fallback", w.marker.FallbackURL, "error", fbErr)
 				return
 			}
 			if services.GlobalCacheIndex != nil {
@@ -691,9 +705,6 @@ func (h *StaticMapHandler) downloadMarkerBytes(ctx context.Context, staticMap mo
 	}
 	wg.Wait()
 
-	if fetchErr != nil {
-		return nil, fetchErr
-	}
 	return result, nil
 }
 

--- a/rampardos/internal/handlers/static_map_race_test.go
+++ b/rampardos/internal/handlers/static_map_race_test.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/lenisko/rampardos/internal/models"
+)
+
+// raceTestHandler returns a handler wired up so that base generation
+// is stubbed (no renderer, no tile handler) and returns fakePNG bytes.
+// The atomic counter records how many times the fake renderer ran.
+func raceTestHandler(t *testing.T) (*StaticMapHandler, *atomic.Int32, func()) {
+	t.Helper()
+	h, cleanup := newTestStaticMapHandler(t)
+	var renders atomic.Int32
+	h.stylesController = stubStylesController{ext: nil}
+	h.generateBaseStaticMapFromTilesFn = func(ctx context.Context, sm models.StaticMap, _ *models.Style) ([]byte, error) {
+		renders.Add(1)
+		return fakePNG(t), nil
+	}
+	h.generateBaseStaticMapFromAPIFn = func(ctx context.Context, sm models.StaticMap) ([]byte, error) {
+		renders.Add(1)
+		return fakePNG(t), nil
+	}
+	h.logExternalViewportApproxFn = func(sm models.StaticMap) {}
+	return h, &renders, cleanup
+}
+
+func raceTestStaticMap() models.StaticMap {
+	return models.StaticMap{
+		Style:     "local",
+		Latitude:  51.5,
+		Longitude: 0.0,
+		Zoom:      14,
+		Width:     256,
+		Height:    256,
+	}
+}
+
+// TestBaseDeletedBetweenCallsDoesNotError verifies that when the base
+// file is deleted externally between requests, the next call
+// regenerates it — no stale cache-index false positives.
+func TestBaseDeletedBetweenCallsDoesNotError(t *testing.T) {
+	h, renders, cleanup := raceTestHandler(t)
+	defer cleanup()
+
+	sm := raceTestStaticMap()
+	basePath := sm.BasePath()
+	ctx := context.Background()
+
+	// First call renders + persists.
+	b1, err := h.loadOrRenderBaseBytes(ctx, sm, basePath)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if len(b1) == 0 {
+		t.Fatal("first load returned empty bytes")
+	}
+	if renders.Load() != 1 {
+		t.Fatalf("expected 1 render after first call, got %d", renders.Load())
+	}
+	if _, err := os.Stat(basePath); err != nil {
+		t.Fatalf("expected persisted base at %s: %v", basePath, err)
+	}
+
+	// External deletion of the shared base.
+	if err := os.Remove(basePath); err != nil {
+		t.Fatalf("remove base: %v", err)
+	}
+
+	// Second call must not fail and must re-render.
+	b2, err := h.loadOrRenderBaseBytes(ctx, sm, basePath)
+	if err != nil {
+		t.Fatalf("second load after base delete: %v", err)
+	}
+	if len(b2) == 0 {
+		t.Fatal("second load returned empty bytes")
+	}
+	if renders.Load() != 2 {
+		t.Fatalf("expected 2 renders after re-trigger, got %d", renders.Load())
+	}
+}
+
+// TestConcurrentSiblingBaseSingleflight verifies that N concurrent
+// requests for the same basePath render it exactly once.
+func TestConcurrentSiblingBaseSingleflight(t *testing.T) {
+	h, renders, cleanup := raceTestHandler(t)
+	defer cleanup()
+
+	sm := raceTestStaticMap()
+	basePath := sm.BasePath()
+	ctx := context.Background()
+
+	const N = 8
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := h.loadOrRenderBaseBytes(ctx, sm, basePath); err != nil {
+				t.Errorf("load: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got := renders.Load()
+	if got != 1 {
+		t.Fatalf("expected 1 base render for %d concurrent callers, got %d", N, got)
+	}
+}

--- a/rampardos/internal/handlers/static_map_race_test.go
+++ b/rampardos/internal/handlers/static_map_race_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/lenisko/rampardos/internal/models"
 )
@@ -87,15 +88,39 @@ func TestBaseDeletedBetweenCallsDoesNotError(t *testing.T) {
 
 // TestConcurrentSiblingBaseSingleflight verifies that N concurrent
 // requests for the same basePath render it exactly once.
+//
+// Determinism: the fake render fn blocks on a gate so the leader
+// cannot release the singleflight slot before followers arrive. A
+// previous version of this test let the leader finish synchronously,
+// which meant the singleflight dedupe could be bypassed by luck
+// (goroutine 2 entering Do after goroutine 1 had already returned).
 func TestConcurrentSiblingBaseSingleflight(t *testing.T) {
-	h, renders, cleanup := raceTestHandler(t)
+	h, cleanup := newTestStaticMapHandler(t)
 	defer cleanup()
+	h.stylesController = stubStylesController{ext: nil}
+	h.logExternalViewportApproxFn = func(sm models.StaticMap) {}
+
+	const N = 8
+	var renders atomic.Int32
+	reached := make(chan struct{}, N+1)
+	gate := make(chan struct{})
+	h.generateBaseStaticMapFromTilesFn = func(ctx context.Context, sm models.StaticMap, _ *models.Style) ([]byte, error) {
+		renders.Add(1)
+		reached <- struct{}{}
+		<-gate
+		return fakePNG(t), nil
+	}
+	h.generateBaseStaticMapFromAPIFn = func(ctx context.Context, sm models.StaticMap) ([]byte, error) {
+		renders.Add(1)
+		reached <- struct{}{}
+		<-gate
+		return fakePNG(t), nil
+	}
 
 	sm := raceTestStaticMap()
 	basePath := sm.BasePath()
 	ctx := context.Background()
 
-	const N = 8
 	var wg sync.WaitGroup
 	for i := 0; i < N; i++ {
 		wg.Add(1)
@@ -106,10 +131,20 @@ func TestConcurrentSiblingBaseSingleflight(t *testing.T) {
 			}
 		}()
 	}
+
+	// Wait for the singleflight leader to reach the render fn. If
+	// singleflight dedupes correctly, exactly one goroutine arrives.
+	<-reached
+	// Give the scheduler room to park the other N-1 goroutines inside
+	// baseSfg.Do. They should all be suspended on the shared key.
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
 	wg.Wait()
 
-	got := renders.Load()
-	if got != 1 {
+	if got := renders.Load(); got != 1 {
 		t.Fatalf("expected 1 base render for %d concurrent callers, got %d", N, got)
+	}
+	if extra := len(reached); extra != 0 {
+		t.Fatalf("expected no extra render fn entries, got %d", extra)
 	}
 }

--- a/rampardos/internal/handlers/static_map_test.go
+++ b/rampardos/internal/handlers/static_map_test.go
@@ -3,8 +3,6 @@ package handlers
 import (
 	"context"
 	"math"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/lenisko/rampardos/internal/models"
@@ -56,14 +54,14 @@ func newDispatchHandlerForTest(t *testing.T, ext *models.Style, rec *dispatchRec
 	h := &StaticMapHandler{
 		stylesController: stubStylesController{ext: ext},
 	}
-	h.generateBaseStaticMapFromAPIFn = func(ctx context.Context, sm models.StaticMap, basePath string) error {
+	h.generateBaseStaticMapFromAPIFn = func(ctx context.Context, sm models.StaticMap) ([]byte, error) {
 		rec.fromAPI++
-		return nil
+		return []byte{0x89, 'P', 'N', 'G'}, nil
 	}
-	h.generateBaseStaticMapFromTilesFn = func(ctx context.Context, sm models.StaticMap, basePath string, extStyle *models.Style) error {
+	h.generateBaseStaticMapFromTilesFn = func(ctx context.Context, sm models.StaticMap, extStyle *models.Style) ([]byte, error) {
 		rec.fromTiles++
 		rec.lastExt = extStyle
-		return nil
+		return []byte{0x89, 'P', 'N', 'G'}, nil
 	}
 	h.logExternalViewportApproxFn = func(sm models.StaticMap) {
 		rec.lastWarn = true
@@ -77,15 +75,12 @@ func (s stubStylesController) GetExternalStyle(name string) *models.Style { retu
 
 func TestGenerateBaseStaticMapDispatch(t *testing.T) {
 	ctx := context.Background()
-	tmp := t.TempDir()
-	basePath := filepath.Join(tmp, "base.png")
-	_ = os.Remove(basePath)
 
 	t.Run("local integer zoom -> stitch", func(t *testing.T) {
 		rec := &dispatchRecord{}
 		h := newDispatchHandlerForTest(t, nil, rec)
 		sm := models.StaticMap{Style: "local", Zoom: 14, Width: 512, Height: 512}
-		if err := h.generateBaseStaticMap(ctx, sm, basePath); err != nil {
+		if _, err := h.generateBaseStaticMap(ctx, sm); err != nil {
 			t.Fatal(err)
 		}
 		if rec.fromTiles != 1 || rec.fromAPI != 0 {
@@ -104,7 +99,7 @@ func TestGenerateBaseStaticMapDispatch(t *testing.T) {
 		ext := &models.Style{ID: "ext", URL: "https://x/y/{z}/{x}/{y}.png"}
 		h := newDispatchHandlerForTest(t, ext, rec)
 		sm := models.StaticMap{Style: "ext", Zoom: 14, Width: 512, Height: 512}
-		if err := h.generateBaseStaticMap(ctx, sm, basePath); err != nil {
+		if _, err := h.generateBaseStaticMap(ctx, sm); err != nil {
 			t.Fatal(err)
 		}
 		if rec.fromTiles != 1 || rec.fromAPI != 0 {
@@ -122,7 +117,7 @@ func TestGenerateBaseStaticMapDispatch(t *testing.T) {
 		rec := &dispatchRecord{}
 		h := newDispatchHandlerForTest(t, nil, rec)
 		sm := models.StaticMap{Style: "local", Zoom: 14.7, Width: 512, Height: 512}
-		if err := h.generateBaseStaticMap(ctx, sm, basePath); err != nil {
+		if _, err := h.generateBaseStaticMap(ctx, sm); err != nil {
 			t.Fatal(err)
 		}
 		if rec.fromAPI != 1 || rec.fromTiles != 0 {
@@ -138,7 +133,7 @@ func TestGenerateBaseStaticMapDispatch(t *testing.T) {
 		ext := &models.Style{ID: "ext", URL: "https://x/y/{z}/{x}/{y}.png"}
 		h := newDispatchHandlerForTest(t, ext, rec)
 		sm := models.StaticMap{Style: "ext", Zoom: 14.7, Width: 512, Height: 512}
-		if err := h.generateBaseStaticMap(ctx, sm, basePath); err != nil {
+		if _, err := h.generateBaseStaticMap(ctx, sm); err != nil {
 			t.Fatal(err)
 		}
 		if rec.fromTiles != 1 || rec.fromAPI != 0 {
@@ -162,9 +157,6 @@ func TestGenerateBaseStaticMapFromAPIUsesRenderer(t *testing.T) {
 	h.generateBaseStaticMapFromTilesFn = h.generateBaseStaticMapFromTiles
 	h.logExternalViewportApproxFn = h.logExternalViewportApprox
 
-	tmp := t.TempDir()
-	basePath := filepath.Join(tmp, "base.png")
-
 	sm := models.StaticMap{
 		Style:     "local",
 		Zoom:      14.7,
@@ -174,7 +166,7 @@ func TestGenerateBaseStaticMapFromAPIUsesRenderer(t *testing.T) {
 		Height:    512,
 		Scale:     1,
 	}
-	err := h.generateBaseStaticMapFromAPI(context.Background(), sm, basePath)
+	got, err := h.generateBaseStaticMapFromAPI(context.Background(), sm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,12 +182,8 @@ func TestGenerateBaseStaticMapFromAPIUsesRenderer(t *testing.T) {
 		t.Errorf("zoom: got %v, want 14.7", call.Viewport.Zoom)
 	}
 
-	// Verify bytes landed on disk.
-	got, err := os.ReadFile(basePath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Verify bytes were returned.
 	if len(got) == 0 {
-		t.Errorf("basePath is empty")
+		t.Errorf("returned bytes are empty")
 	}
 }

--- a/rampardos/internal/handlers/static_map_testhelpers_test.go
+++ b/rampardos/internal/handlers/static_map_testhelpers_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"testing"
+
+	"github.com/lenisko/rampardos/internal/services"
+	"github.com/lenisko/rampardos/internal/utils"
+)
+
+// fakePNG returns a valid 1x1 PNG for tests.
+func fakePNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{R: 0, G: 0, B: 0, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// newTestStaticMapHandler builds a handler with a tmp working dir and
+// minimal dependencies for marker-download testing. Returns handler
+// and cleanup func.
+func newTestStaticMapHandler(t *testing.T) (*StaticMapHandler, func()) {
+	t.Helper()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	// DownloadBytes requires globalHTTPService to be initialised.
+	if !services.HTTPServiceInitialized() {
+		services.InitHTTPServiceForTest()
+	}
+
+	// Pass nil statsController — downloadMarkerBytes guards against nil.
+	h := &StaticMapHandler{
+		sphericalMercator: utils.NewSphericalMercator(),
+		statsController:   nil,
+	}
+
+	return h, func() {
+		_ = os.Chdir(origDir)
+	}
+}

--- a/rampardos/internal/services/cache_cleaner.go
+++ b/rampardos/internal/services/cache_cleaner.go
@@ -277,16 +277,15 @@ func (cc *CacheCleaner) shouldRemove(info os.FileInfo, cutoff, dropCutoff time.T
 	return false
 }
 
-// removeFromCacheIndex removes a path from the appropriate cache index based on folder
+// removeFromCacheIndex removes a path from the appropriate cache index
+// based on folder. Only final static/multi-static paths are indexed;
+// Cache/Tile and Cache/Marker are not (the index entries gave no
+// measurable benefit for those paths).
 func (cc *CacheCleaner) removeFromCacheIndex(path string) {
 	switch {
 	case strings.HasPrefix(cc.folder, "Cache/StaticMulti"):
 		GlobalCacheIndex.RemoveMultiStaticMap(path)
 	case strings.HasPrefix(cc.folder, "Cache/Static"):
 		GlobalCacheIndex.RemoveStaticMap(path)
-	case strings.HasPrefix(cc.folder, "Cache/Marker"):
-		GlobalCacheIndex.RemoveMarker(path)
-	case strings.HasPrefix(cc.folder, "Cache/Tile"):
-		GlobalCacheIndex.RemoveTile(path)
 	}
 }

--- a/rampardos/internal/services/cache_cleaner.go
+++ b/rampardos/internal/services/cache_cleaner.go
@@ -282,6 +282,8 @@ func (cc *CacheCleaner) shouldRemove(info os.FileInfo, cutoff, dropCutoff time.T
 // Cache/Tile and Cache/Marker are not (the index entries gave no
 // measurable benefit for those paths).
 func (cc *CacheCleaner) removeFromCacheIndex(path string) {
+	// StaticMulti must be checked first — "Cache/Static" is a prefix
+	// of "Cache/StaticMulti", so the broader case would shadow it.
 	switch {
 	case strings.HasPrefix(cc.folder, "Cache/StaticMulti"):
 		GlobalCacheIndex.RemoveMultiStaticMap(path)

--- a/rampardos/internal/services/cache_index.go
+++ b/rampardos/internal/services/cache_index.go
@@ -155,9 +155,3 @@ func (c *CacheIndex) RemoveMultiStaticMap(path string) {
 	delete(c.multiStaticMaps, path)
 }
 
-// Stats returns cache index statistics.
-func (c *CacheIndex) Stats() (staticMaps, multiStaticMaps int) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.staticMaps), len(c.multiStaticMaps)
-}

--- a/rampardos/internal/services/cache_index.go
+++ b/rampardos/internal/services/cache_index.go
@@ -13,15 +13,19 @@ type markerImageEntry struct {
 	image image.Image
 }
 
-// CacheIndex maintains an in-memory index of cached files to reduce syscalls
+// CacheIndex maintains an in-memory index of cached files to reduce
+// syscalls on the serve path. Only the final staticmap/multistaticmap
+// paths are indexed — tile and marker caches are managed entirely via
+// the filesystem and CacheCleaner, since in-memory presence checks
+// gave no measurable benefit for those paths.
 type CacheIndex struct {
 	staticMaps      map[string]struct{}
 	multiStaticMaps map[string]struct{}
-	markers         map[string]struct{}
-	tiles           map[string]struct{}
 	mu              sync.RWMutex
 
-	// LRU cache for resized marker images (path+size -> image.Image)
+	// LRU cache for resized marker images (path+size -> image.Image).
+	// Unlike the file-presence indices, this saves real work — decode
+	// plus bicubic resize is millisecond-scale per marker.
 	markerImages    map[string]*list.Element
 	markerImagesLRU *list.List
 	markerImagesMax int
@@ -36,8 +40,6 @@ func NewCacheIndex() *CacheIndex {
 	return &CacheIndex{
 		staticMaps:      make(map[string]struct{}),
 		multiStaticMaps: make(map[string]struct{}),
-		markers:         make(map[string]struct{}),
-		tiles:           make(map[string]struct{}),
 		markerImages:    make(map[string]*list.Element),
 		markerImagesLRU: list.New(),
 		markerImagesMax: 500, // Default, can be changed via SetMarkerImageCacheSize
@@ -153,53 +155,9 @@ func (c *CacheIndex) RemoveMultiStaticMap(path string) {
 	delete(c.multiStaticMaps, path)
 }
 
-// HasMarker checks if a marker is in the cache index
-func (c *CacheIndex) HasMarker(path string) bool {
+// Stats returns cache index statistics.
+func (c *CacheIndex) Stats() (staticMaps, multiStaticMaps int) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	_, ok := c.markers[path]
-	return ok
-}
-
-// AddMarker adds a marker to the cache index
-func (c *CacheIndex) AddMarker(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.markers[path] = struct{}{}
-}
-
-// RemoveMarker removes a marker from the cache index
-func (c *CacheIndex) RemoveMarker(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.markers, path)
-}
-
-// HasTile checks if a tile is in the cache index
-func (c *CacheIndex) HasTile(path string) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	_, ok := c.tiles[path]
-	return ok
-}
-
-// AddTile adds a tile to the cache index
-func (c *CacheIndex) AddTile(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.tiles[path] = struct{}{}
-}
-
-// RemoveTile removes a tile from the cache index
-func (c *CacheIndex) RemoveTile(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.tiles, path)
-}
-
-// Stats returns cache index statistics
-func (c *CacheIndex) Stats() (staticMaps, multiStaticMaps, markers, tiles int) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.staticMaps), len(c.multiStaticMaps), len(c.markers), len(c.tiles)
+	return len(c.staticMaps), len(c.multiStaticMaps)
 }

--- a/rampardos/internal/services/http.go
+++ b/rampardos/internal/services/http.go
@@ -231,9 +231,17 @@ func DownloadBytes(ctx context.Context, fromURL, cachePath, expectedType string,
 		}
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	// Cap body size to prevent a malicious or misconfigured upstream
+	// from OOMing the server. Markers and other assets fetched through
+	// DownloadBytes are image files in the low-KB range; 32 MiB is
+	// comfortably above any legitimate payload.
+	const maxDownloadBytes = 32 << 20
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxDownloadBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if int64(len(data)) > maxDownloadBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxDownloadBytes)
 	}
 	if len(data) == 0 {
 		return nil, fmt.Errorf("empty response body")

--- a/rampardos/internal/services/http.go
+++ b/rampardos/internal/services/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -165,4 +166,109 @@ func HTTPGet(ctx context.Context, fromURL string, timeout time.Duration) (*http.
 
 func hasPrefix(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// HTTPServiceInitialized reports whether the global HTTP service has been
+// initialised. Useful in tests to avoid double-init.
+func HTTPServiceInitialized() bool { return globalHTTPService != nil }
+
+// InitHTTPServiceForTest initialises the global HTTP service with simple
+// in-memory clients suitable for unit tests.
+func InitHTTPServiceForTest() {
+	globalHTTPService = &HTTPService{
+		generalClient:  &http.Client{Timeout: 30 * time.Second},
+		downloadClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// DownloadBytes fetches a URL and returns the body as bytes. When
+// cachePath is non-empty, bytes are also persisted atomically to
+// that path (useful for marker caching: the bytes returned to the
+// caller are race-free; the disk copy is best-effort).
+// expectedType, if set, is matched against the response's Content-Type.
+// A cachePath write failure is non-fatal: DownloadBytes returns the
+// bytes and logs a warning — the in-memory bytes are the authoritative
+// result for the caller.
+func DownloadBytes(ctx context.Context, fromURL, cachePath, expectedType string, timeout time.Duration) ([]byte, error) {
+	if globalHTTPService == nil {
+		return nil, fmt.Errorf("HTTP service not initialized")
+	}
+	parsedURL, err := url.Parse(fromURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	host := parsedURL.Host
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	startTime := time.Now()
+	GlobalMetrics.RecordHTTPClientRequest(host)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fromURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "TileserverCache")
+
+	resp, err := globalHTTPService.downloadClient.Do(req)
+	if err != nil {
+		GlobalMetrics.RecordHTTPClientError(host)
+		return nil, fmt.Errorf("failed to download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	GlobalMetrics.RecordHTTPClientDuration(host, time.Since(startTime).Seconds())
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		GlobalMetrics.RecordHTTPClientError(host)
+		GlobalMetrics.RecordError("http_client", fmt.Sprintf("status_%d", resp.StatusCode))
+		return nil, fmt.Errorf("http %d", resp.StatusCode)
+	}
+
+	if expectedType != "" {
+		if ct := resp.Header.Get("Content-Type"); ct != "" && !hasPrefix(ct, expectedType) {
+			return nil, fmt.Errorf("invalid content type %q", ct)
+		}
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty response body")
+	}
+
+	if cachePath != "" {
+		if err := saveBytesAtomic(cachePath, data); err != nil {
+			slog.Warn("DownloadBytes: cache write failed", "path", cachePath, "error", err)
+		}
+	}
+	return data, nil
+}
+
+// saveBytesAtomic writes data to path via temp file + rename.
+func saveBytesAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
 }

--- a/rampardos/internal/services/http.go
+++ b/rampardos/internal/services/http.go
@@ -240,15 +240,17 @@ func DownloadBytes(ctx context.Context, fromURL, cachePath, expectedType string,
 	}
 
 	if cachePath != "" {
-		if err := saveBytesAtomic(cachePath, data); err != nil {
+		if err := SaveBytesAtomic(cachePath, data); err != nil {
 			slog.Warn("DownloadBytes: cache write failed", "path", cachePath, "error", err)
 		}
 	}
 	return data, nil
 }
 
-// saveBytesAtomic writes data to path via temp file + rename.
-func saveBytesAtomic(path string, data []byte) error {
+// SaveBytesAtomic writes data to path via temp file + rename. Callers
+// across packages use this as the canonical atomic-write primitive
+// (utils.SaveImageBytes and handlers.atomicWriteFile both delegate).
+func SaveBytesAtomic(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/rampardos/internal/utils/image_bytes.go
+++ b/rampardos/internal/utils/image_bytes.go
@@ -6,6 +6,8 @@ import (
 	"image"
 	"image/jpeg"
 	"image/png"
+	"os"
+	"path/filepath"
 
 	"github.com/gen2brain/webp"
 	"github.com/lenisko/rampardos/internal/models"
@@ -41,4 +43,32 @@ func encodeImage(img image.Image, format models.ImageFormat) ([]byte, error) {
 		return nil, fmt.Errorf("unsupported image format %q", format)
 	}
 	return buf.Bytes(), nil
+}
+
+// SaveImageBytes atomically writes encoded image bytes to path. The
+// parent directory is created if needed. Uses a temp file in the same
+// directory followed by rename, so readers never observe a partial file.
+func SaveImageBytes(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
 }

--- a/rampardos/internal/utils/image_bytes.go
+++ b/rampardos/internal/utils/image_bytes.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
+
+	"github.com/gen2brain/webp"
+	"github.com/lenisko/rampardos/internal/models"
+)
+
+// decodeImage decodes PNG/JPEG/WEBP/GIF bytes via the stdlib image
+// registry (format detection is handled by the imported decoders).
+func decodeImage(b []byte) (image.Image, error) {
+	img, _, err := image.Decode(bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("decode image: %w", err)
+	}
+	return img, nil
+}
+
+// encodeImage encodes img in the requested format.
+func encodeImage(img image.Image, format models.ImageFormat) ([]byte, error) {
+	var buf bytes.Buffer
+	switch format {
+	case models.ImageFormatPNG, "":
+		if err := png.Encode(&buf, img); err != nil {
+			return nil, fmt.Errorf("png encode: %w", err)
+		}
+	case models.ImageFormatJPG, models.ImageFormatJPEG:
+		if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}); err != nil {
+			return nil, fmt.Errorf("jpeg encode: %w", err)
+		}
+	case models.ImageFormatWEBP:
+		if err := webp.Encode(&buf, img); err != nil {
+			return nil, fmt.Errorf("webp encode: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported image format %q", format)
+	}
+	return buf.Bytes(), nil
+}

--- a/rampardos/internal/utils/image_bytes.go
+++ b/rampardos/internal/utils/image_bytes.go
@@ -6,12 +6,28 @@ import (
 	"image"
 	"image/jpeg"
 	"image/png"
-	"os"
-	"path/filepath"
 
 	"github.com/gen2brain/webp"
 	"github.com/lenisko/rampardos/internal/models"
+	"github.com/lenisko/rampardos/internal/services"
 )
+
+// imageQuality returns the configured JPEG/WebP quality (1-100) or 90
+// if GlobalImageSettings is unset or zero. Matches saveImage.
+func imageQuality() int {
+	if services.GlobalImageSettings != nil && services.GlobalImageSettings.ImageQuality > 0 {
+		return services.GlobalImageSettings.ImageQuality
+	}
+	return 90
+}
+
+// pngCompression returns the configured PNG compression level. Matches saveImage.
+func pngCompression() png.CompressionLevel {
+	if services.GlobalImageSettings != nil {
+		return services.GlobalImageSettings.PNGCompressionLevel
+	}
+	return png.BestCompression
+}
 
 // decodeImage decodes PNG/JPEG/WEBP/GIF bytes via the stdlib image
 // registry (format detection is handled by the imported decoders).
@@ -23,20 +39,23 @@ func decodeImage(b []byte) (image.Image, error) {
 	return img, nil
 }
 
-// encodeImage encodes img in the requested format.
+// encodeImage encodes img in the requested format, honouring
+// services.GlobalImageSettings for JPEG/WebP quality and PNG compression
+// so the bytes-first pipeline matches legacy saveImage behaviour.
 func encodeImage(img image.Image, format models.ImageFormat) ([]byte, error) {
 	var buf bytes.Buffer
 	switch format {
 	case models.ImageFormatPNG, "":
-		if err := png.Encode(&buf, img); err != nil {
+		encoder := &png.Encoder{CompressionLevel: pngCompression()}
+		if err := encoder.Encode(&buf, img); err != nil {
 			return nil, fmt.Errorf("png encode: %w", err)
 		}
 	case models.ImageFormatJPG, models.ImageFormatJPEG:
-		if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}); err != nil {
+		if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: imageQuality()}); err != nil {
 			return nil, fmt.Errorf("jpeg encode: %w", err)
 		}
 	case models.ImageFormatWEBP:
-		if err := webp.Encode(&buf, img); err != nil {
+		if err := webp.Encode(&buf, img, webp.Options{Quality: imageQuality()}); err != nil {
 			return nil, fmt.Errorf("webp encode: %w", err)
 		}
 	default:
@@ -45,30 +64,10 @@ func encodeImage(img image.Image, format models.ImageFormat) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// SaveImageBytes atomically writes encoded image bytes to path. The
-// parent directory is created if needed. Uses a temp file in the same
-// directory followed by rename, so readers never observe a partial file.
+// SaveImageBytes atomically writes encoded image bytes to path. Delegates
+// to services.SaveBytesAtomic so the three historical atomic-write paths
+// (here, services.DownloadBytes cache, handlers.atomicWriteFile) share
+// one implementation.
 func SaveImageBytes(path string, data []byte) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("mkdir: %w", err)
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
-	if err != nil {
-		return fmt.Errorf("create temp: %w", err)
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return fmt.Errorf("write temp: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
-		return fmt.Errorf("close temp: %w", err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
-		return fmt.Errorf("rename: %w", err)
-	}
-	return nil
+	return services.SaveBytesAtomic(path, data)
 }

--- a/rampardos/internal/utils/image_bytes_test.go
+++ b/rampardos/internal/utils/image_bytes_test.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+
+	"github.com/lenisko/rampardos/internal/models"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+
+	b, err := encodeImage(img, models.ImageFormatPNG)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := decodeImage(b)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Bounds() != img.Bounds() {
+		t.Fatalf("bounds mismatch: got %v want %v", got.Bounds(), img.Bounds())
+	}
+
+	// Sanity: re-encode and parse as PNG to confirm format.
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, got); err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+}
+
+func TestDecodeInvalidBytes(t *testing.T) {
+	if _, err := decodeImage([]byte("not an image")); err == nil {
+		t.Fatal("expected error decoding garbage")
+	}
+}

--- a/rampardos/internal/utils/image_bytes_test.go
+++ b/rampardos/internal/utils/image_bytes_test.go
@@ -5,6 +5,8 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/lenisko/rampardos/internal/models"
@@ -36,5 +38,52 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 func TestDecodeInvalidBytes(t *testing.T) {
 	if _, err := decodeImage([]byte("not an image")); err == nil {
 		t.Fatal("expected error decoding garbage")
+	}
+}
+
+func TestGenerateStaticMapBytes_NoDrawables(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	baseBytes, err := encodeImage(img, models.ImageFormatPNG)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	pngFmt := models.ImageFormatPNG
+	sm := models.StaticMap{Width: 8, Height: 8, Zoom: 10, Latitude: 0, Longitude: 0, Format: &pngFmt}
+
+	out, err := GenerateStaticMapBytes(sm, baseBytes, nil, NewSphericalMercator())
+	if err != nil {
+		t.Fatalf("GenerateStaticMapBytes: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+	if _, err := decodeImage(out); err != nil {
+		t.Fatalf("output not decodable: %v", err)
+	}
+}
+
+func TestGenerateStaticMapBytes_FileWrapperStillWorks(t *testing.T) {
+	// Legacy GenerateStaticMapNative file-path path must still work:
+	// write a base to a temp dir, call the file-path wrapper, read the result.
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "base.png")
+	out := filepath.Join(tmp, "out.png")
+
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	b, err := encodeImage(img, models.ImageFormatPNG)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := os.WriteFile(base, b, 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+
+	pngFmt2 := models.ImageFormatPNG
+	sm := models.StaticMap{Width: 8, Height: 8, Zoom: 10, Latitude: 0, Longitude: 0, Format: &pngFmt2}
+	if err := GenerateStaticMap(sm, base, out, NewSphericalMercator()); err != nil {
+		t.Fatalf("GenerateStaticMap: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("expected output file: %v", err)
 	}
 }

--- a/rampardos/internal/utils/image_bytes_test.go
+++ b/rampardos/internal/utils/image_bytes_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"image"
 	"image/color"
+	"image/draw"
 	"image/png"
 	"os"
 	"path/filepath"
@@ -60,6 +61,47 @@ func TestGenerateStaticMapBytes_NoDrawables(t *testing.T) {
 	if _, err := decodeImage(out); err != nil {
 		t.Fatalf("output not decodable: %v", err)
 	}
+}
+
+func TestComposeMultiStaticMapBytes_TwoHorizontal(t *testing.T) {
+	red := uniformPNG(t, color.RGBA{R: 255, A: 255})
+	blue := uniformPNG(t, color.RGBA{B: 255, A: 255})
+
+	msm := models.MultiStaticMap{
+		Grid: []models.DirectionedMultiStaticMap{
+			{
+				Direction: models.CombineDirectionFirst,
+				Maps: []models.DirectionedStaticMap{
+					{Map: models.StaticMap{}, Direction: models.CombineDirectionFirst},
+					{Map: models.StaticMap{}, Direction: models.CombineDirectionRight},
+				},
+			},
+		},
+	}
+
+	out, err := ComposeMultiStaticMapBytes(msm, [][]byte{red, blue})
+	if err != nil {
+		t.Fatalf("compose: %v", err)
+	}
+	got, err := decodeImage(out)
+	if err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if got.Bounds().Dx() != 16 || got.Bounds().Dy() != 8 {
+		t.Fatalf("bounds: got %v want 16x8", got.Bounds())
+	}
+}
+
+// uniformPNG returns an 8x8 PNG filled with c.
+func uniformPNG(t *testing.T, c color.Color) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	draw.Draw(img, img.Bounds(), &image.Uniform{C: c}, image.Point{}, draw.Src)
+	b, err := encodeImage(img, models.ImageFormatPNG)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return b
 }
 
 func TestGenerateStaticMapBytes_FileWrapperStillWorks(t *testing.T) {

--- a/rampardos/internal/utils/image_bytes_test.go
+++ b/rampardos/internal/utils/image_bytes_test.go
@@ -104,6 +104,55 @@ func uniformPNG(t *testing.T, c color.Color) []byte {
 	return b
 }
 
+// TestComposeMultiStaticMapBytes_ImmuneToComponentDeletion verifies
+// the invariant Task 7 depends on: once components are held as
+// [][]byte, the stitcher cannot be affected by concurrent deletion
+// of any on-disk copies. This test pre-populates on-disk copies,
+// deletes them before compose, and confirms the compose still
+// produces a valid image.
+func TestComposeMultiStaticMapBytes_ImmuneToComponentDeletion(t *testing.T) {
+	red := uniformPNG(t, color.RGBA{R: 255, A: 255})
+	blue := uniformPNG(t, color.RGBA{B: 255, A: 255})
+
+	tmp := t.TempDir()
+	redPath := filepath.Join(tmp, "red.png")
+	bluePath := filepath.Join(tmp, "blue.png")
+	if err := os.WriteFile(redPath, red, 0o644); err != nil {
+		t.Fatalf("write red: %v", err)
+	}
+	if err := os.WriteFile(bluePath, blue, 0o644); err != nil {
+		t.Fatalf("write blue: %v", err)
+	}
+
+	// Simulate CacheCleaner sweep between component fetch and stitch.
+	if err := os.Remove(redPath); err != nil {
+		t.Fatalf("remove red: %v", err)
+	}
+	if err := os.Remove(bluePath); err != nil {
+		t.Fatalf("remove blue: %v", err)
+	}
+
+	msm := models.MultiStaticMap{
+		Grid: []models.DirectionedMultiStaticMap{
+			{
+				Direction: models.CombineDirectionFirst,
+				Maps: []models.DirectionedStaticMap{
+					{Map: models.StaticMap{}, Direction: models.CombineDirectionFirst},
+					{Map: models.StaticMap{}, Direction: models.CombineDirectionRight},
+				},
+			},
+		},
+	}
+
+	out, err := ComposeMultiStaticMapBytes(msm, [][]byte{red, blue})
+	if err != nil {
+		t.Fatalf("compose after component deletion: %v", err)
+	}
+	if _, err := decodeImage(out); err != nil {
+		t.Fatalf("output not decodable: %v", err)
+	}
+}
+
 func TestGenerateStaticMapBytes_FileWrapperStillWorks(t *testing.T) {
 	// Legacy GenerateStaticMapNative file-path path must still work:
 	// write a base to a temp dir, call the file-path wrapper, read the result.

--- a/rampardos/internal/utils/image_utils.go
+++ b/rampardos/internal/utils/image_utils.go
@@ -16,6 +16,14 @@ func GenerateBaseStaticMap(staticMap models.StaticMap, tilePaths []string, path 
 	return GenerateBaseStaticMapNative(staticMap, tilePaths, path, offsetX, offsetY, hasScale, redownload)
 }
 
+// ComposeBaseStaticMapBytes stitches tile images and crops to the
+// requested viewport, returning the encoded result. Equivalent to
+// GenerateBaseStaticMap but with no disk write — callers decide
+// whether to persist the returned bytes.
+func ComposeBaseStaticMapBytes(staticMap models.StaticMap, tilePaths []string, offsetX, offsetY int, hasScale bool, redownload TileRedownloader) ([]byte, error) {
+	return composeBaseStaticMapBytesNative(staticMap, tilePaths, offsetX, offsetY, hasScale, redownload)
+}
+
 // GenerateStaticMap adds markers, polygons, and circles to a base map
 func GenerateStaticMap(staticMap models.StaticMap, basePath, path string, sm *SphericalMercator) error {
 	return GenerateStaticMapNative(staticMap, basePath, path, sm)

--- a/rampardos/internal/utils/image_utils.go
+++ b/rampardos/internal/utils/image_utils.go
@@ -44,6 +44,13 @@ func GenerateMultiStaticMap(multiStaticMap models.MultiStaticMap, path string) e
 	return GenerateMultiStaticMapNative(multiStaticMap, path)
 }
 
+// ComposeMultiStaticMapBytes composes pre-encoded component images
+// into the final grid image. componentBytes must be in grid iteration
+// order (outer: grids, inner: maps within each grid, flattened).
+func ComposeMultiStaticMapBytes(multiStaticMap models.MultiStaticMap, componentBytes [][]byte) ([]byte, error) {
+	return composeMultiStaticMapBytesNative(multiStaticMap, componentBytes)
+}
+
 type offsetResult struct {
 	x, y int
 }

--- a/rampardos/internal/utils/image_utils.go
+++ b/rampardos/internal/utils/image_utils.go
@@ -21,6 +21,16 @@ func GenerateStaticMap(staticMap models.StaticMap, basePath, path string, sm *Sp
 	return GenerateStaticMapNative(staticMap, basePath, path, sm)
 }
 
+// GenerateStaticMapBytes draws overlays (markers/polygons/circles) onto
+// an already-encoded base image in memory and returns the encoded result.
+// No disk access for the base — callers hold the base bytes, so external
+// file deletion cannot affect this path. Markers may be supplied via
+// markerBytes (keyed by getMarkerPath(marker)); absent keys fall back to
+// the disk read in drawOverlays for legacy callers.
+func GenerateStaticMapBytes(staticMap models.StaticMap, baseBytes []byte, markerBytes map[string][]byte, sm *SphericalMercator) ([]byte, error) {
+	return generateStaticMapBytesNative(staticMap, baseBytes, markerBytes, sm)
+}
+
 // GenerateMultiStaticMap combines multiple static maps into a grid
 func GenerateMultiStaticMap(multiStaticMap models.MultiStaticMap, path string) error {
 	return GenerateMultiStaticMapNative(multiStaticMap, path)

--- a/rampardos/internal/utils/image_utils.go
+++ b/rampardos/internal/utils/image_utils.go
@@ -68,7 +68,10 @@ func getRealOffset(at, center models.Coordinate, zoom float64, scale uint8, extr
 	}
 }
 
-func getMarkerPath(marker models.Marker) string {
+// GetMarkerPath returns the cache path for the given marker's primary URL.
+// Remote markers (http/https) are stored as Cache/Marker/<hash>.<ext>;
+// bundled markers are stored as Markers/<filename>.
+func GetMarkerPath(marker models.Marker) string {
 	if strings.HasPrefix(marker.URL, "http://") || strings.HasPrefix(marker.URL, "https://") {
 		hash := PersistentHashString(marker.URL)
 		parts := strings.Split(marker.URL, ".")
@@ -81,7 +84,8 @@ func getMarkerPath(marker models.Marker) string {
 	return fmt.Sprintf("Markers/%s", marker.URL)
 }
 
-func getFallbackMarkerPath(marker models.Marker) string {
+// GetFallbackMarkerPath returns the cache path for the given marker's fallback URL.
+func GetFallbackMarkerPath(marker models.Marker) string {
 	if strings.HasPrefix(marker.FallbackURL, "http://") || strings.HasPrefix(marker.FallbackURL, "https://") {
 		hash := PersistentHashString(marker.FallbackURL)
 		parts := strings.Split(marker.FallbackURL, ".")

--- a/rampardos/internal/utils/image_utils_native.go
+++ b/rampardos/internal/utils/image_utils_native.go
@@ -329,34 +329,52 @@ func drawOverlays(dc *gg.Context, staticMap models.StaticMap, scale uint8, marke
 	return nil
 }
 
-// GenerateMultiStaticMapNative combines multiple static maps into a grid using native Go.
-//
-// This matches ImageMagick's -append/+append behaviour used by the
-// original Swift implementation: each image in a grid group is
-// sequentially appended to the cumulative result, and images are
-// scaled to match the append dimension (height for +append/right,
-// width for -append/bottom) so the seams align cleanly.
+// GenerateMultiStaticMapNative is the legacy file-path entrypoint.
+// Reads each component from disk in grid iteration order and delegates
+// to composeMultiStaticMapBytesNative.
 func GenerateMultiStaticMapNative(multiStaticMap models.MultiStaticMap, path string) error {
-	// Build each grid group as a composite image, then combine groups.
+	var componentBytes [][]byte
+	for _, grid := range multiStaticMap.Grid {
+		for _, m := range grid.Maps {
+			b, err := os.ReadFile(m.Map.Path())
+			if err != nil {
+				return fmt.Errorf("failed to load map %s: %w", m.Map.Path(), err)
+			}
+			componentBytes = append(componentBytes, b)
+		}
+	}
+	out, err := composeMultiStaticMapBytesNative(multiStaticMap, componentBytes)
+	if err != nil {
+		return err
+	}
+	return SaveImageBytes(path, out)
+}
+
+// composeMultiStaticMapBytesNative is the canonical in-memory grid
+// composer. componentBytes must align with the flat iteration order:
+// for each grid, for each map within it, in order.
+func composeMultiStaticMapBytesNative(multiStaticMap models.MultiStaticMap, componentBytes [][]byte) ([]byte, error) {
 	var groupImages []image.Image
 	var groupDirections []models.CombineDirection
 
+	idx := 0
 	for _, grid := range multiStaticMap.Grid {
 		var composite image.Image
 
 		for _, m := range grid.Maps {
-			mapPath := m.Map.Path()
-			img, err := loadImage(mapPath)
+			if idx >= len(componentBytes) {
+				return nil, fmt.Errorf("component bytes underflow at idx %d (got %d entries)", idx, len(componentBytes))
+			}
+			img, err := decodeImage(componentBytes[idx])
+			idx++
 			if err != nil {
-				return fmt.Errorf("failed to load map %s: %w", mapPath, err)
+				return nil, fmt.Errorf("decode component %d: %w", idx-1, err)
 			}
 
 			if m.Direction == models.CombineDirectionFirst || composite == nil {
-				// First image in the group — this is the anchor.
 				composite = img
 				continue
 			}
-
 			composite = appendImages(composite, img, m.Direction)
 		}
 
@@ -367,10 +385,9 @@ func GenerateMultiStaticMapNative(multiStaticMap models.MultiStaticMap, path str
 	}
 
 	if len(groupImages) == 0 {
-		return fmt.Errorf("no images to combine")
+		return nil, fmt.Errorf("no images to combine")
 	}
 
-	// Combine all grid groups together.
 	result := groupImages[0]
 	for i := 1; i < len(groupImages); i++ {
 		dir := groupDirections[i]
@@ -380,7 +397,7 @@ func GenerateMultiStaticMapNative(multiStaticMap models.MultiStaticMap, path str
 		result = appendImages(result, groupImages[i], dir)
 	}
 
-	return saveImage(path, result)
+	return encodeImage(result, models.ImageFormatPNG)
 }
 
 // appendImages combines two images in the given direction, scaling the

--- a/rampardos/internal/utils/image_utils_native.go
+++ b/rampardos/internal/utils/image_utils_native.go
@@ -397,6 +397,10 @@ func composeMultiStaticMapBytesNative(multiStaticMap models.MultiStaticMap, comp
 		result = appendImages(result, groupImages[i], dir)
 	}
 
+	// MultiStaticMap carries no Format field; output is always PNG.
+	// The multi handler's generateResponseBytes sets Content-Type
+	// accordingly. If a future change adds per-multi format support,
+	// thread it through here too.
 	return encodeImage(result, models.ImageFormatPNG)
 }
 

--- a/rampardos/internal/utils/image_utils_native.go
+++ b/rampardos/internal/utils/image_utils_native.go
@@ -274,10 +274,10 @@ func drawOverlays(dc *gg.Context, staticMap models.StaticMap, scale uint8, marke
 			continue
 		}
 
-		markerPath := getMarkerPath(marker)
+		markerPath := GetMarkerPath(marker)
 		if marker.FallbackURL != "" {
 			if _, err := os.Stat(markerPath); os.IsNotExist(err) {
-				markerPath = getFallbackMarkerPath(marker)
+				markerPath = GetFallbackMarkerPath(marker)
 			}
 		}
 
@@ -296,7 +296,7 @@ func drawOverlays(dc *gg.Context, staticMap models.StaticMap, scale uint8, marke
 		// Load and resize if not cached
 		if markerImg == nil {
 			var err error
-			key := getMarkerPath(marker)
+			key := GetMarkerPath(marker)
 			if b, ok := markerBytes[key]; ok {
 				markerImg, err = decodeImage(b)
 			} else {

--- a/rampardos/internal/utils/image_utils_native.go
+++ b/rampardos/internal/utils/image_utils_native.go
@@ -23,10 +23,11 @@ import (
 	_ "golang.org/x/image/webp"
 )
 
-// GenerateBaseStaticMapNative combines tiles into a base static map using native Go
-func GenerateBaseStaticMapNative(staticMap models.StaticMap, tilePaths []string, path string, offsetX, offsetY int, hasScale bool, redownload TileRedownloader) error {
+// composeBaseStaticMapBytesNative stitches tile images and crops to the
+// requested viewport, returning the encoded result with no disk write.
+func composeBaseStaticMapBytesNative(staticMap models.StaticMap, tilePaths []string, offsetX, offsetY int, hasScale bool, redownload TileRedownloader) ([]byte, error) {
 	if len(tilePaths) == 0 {
-		return fmt.Errorf("no tiles to combine")
+		return nil, fmt.Errorf("no tiles to combine")
 	}
 
 	// Sort tile paths for consistent ordering
@@ -41,7 +42,7 @@ func GenerateBaseStaticMapNative(staticMap models.StaticMap, tilePaths []string,
 	for _, tilePath := range sortedPaths {
 		img, err := loadImageWithRetry(tilePath, redownload)
 		if err != nil {
-			return fmt.Errorf("failed to load tile %s: %w", tilePath, err)
+			return nil, fmt.Errorf("failed to load tile %s: %w", tilePath, err)
 		}
 		tiles = append(tiles, img)
 		if tileWidth == 0 {
@@ -119,7 +120,17 @@ func GenerateBaseStaticMapNative(staticMap models.StaticMap, tilePaths []string,
 	draw.Draw(cropped, cropped.Bounds(), combined,
 		image.Point{X: imgWidthOffset, Y: imgHeightOffset}, draw.Src)
 
-	return saveImage(path, cropped)
+	format := staticMap.GetFormat()
+	return encodeImage(cropped, format)
+}
+
+// GenerateBaseStaticMapNative combines tiles into a base static map using native Go
+func GenerateBaseStaticMapNative(staticMap models.StaticMap, tilePaths []string, path string, offsetX, offsetY int, hasScale bool, redownload TileRedownloader) error {
+	b, err := composeBaseStaticMapBytesNative(staticMap, tilePaths, offsetX, offsetY, hasScale, redownload)
+	if err != nil {
+		return err
+	}
+	return SaveImageBytes(path, b)
 }
 
 // GenerateStaticMapNative is the legacy file-path entrypoint. It reads

--- a/rampardos/internal/utils/image_utils_native.go
+++ b/rampardos/internal/utils/image_utils_native.go
@@ -122,15 +122,27 @@ func GenerateBaseStaticMapNative(staticMap models.StaticMap, tilePaths []string,
 	return saveImage(path, cropped)
 }
 
-// GenerateStaticMapNative adds markers, polygons, and circles to a base map using native Go
+// GenerateStaticMapNative is the legacy file-path entrypoint. It reads
+// the base from disk and delegates to the bytes implementation with
+// nil markerBytes (drawOverlays falls back to disk reads for markers).
 func GenerateStaticMapNative(staticMap models.StaticMap, basePath, path string, sm *SphericalMercator) error {
-	// Load base image
-	baseImg, err := loadImage(basePath)
+	baseBytes, err := os.ReadFile(basePath)
 	if err != nil {
 		return fmt.Errorf("failed to load base image: %w", err)
 	}
+	out, err := generateStaticMapBytesNative(staticMap, baseBytes, nil, sm)
+	if err != nil {
+		return err
+	}
+	return SaveImageBytes(path, out)
+}
 
-	// Create drawing context
+// generateStaticMapBytesNative is the canonical in-memory implementation.
+func generateStaticMapBytesNative(staticMap models.StaticMap, baseBytes []byte, markerBytes map[string][]byte, sm *SphericalMercator) ([]byte, error) {
+	baseImg, err := decodeImage(baseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("decode base: %w", err)
+	}
 	dc := gg.NewContextForImage(baseImg)
 
 	scale := staticMap.Scale
@@ -138,6 +150,17 @@ func GenerateStaticMapNative(staticMap models.StaticMap, basePath, path string, 
 		scale = 1
 	}
 
+	if err := drawOverlays(dc, staticMap, scale, markerBytes, sm); err != nil {
+		return nil, err
+	}
+
+	return encodeImage(dc.Image(), staticMap.GetFormat())
+}
+
+// drawOverlays renders polygons, circles, and markers onto dc. Marker
+// images may be supplied via markerBytes (map keyed by getMarkerPath);
+// when a key is missing, the marker is loaded from disk.
+func drawOverlays(dc *gg.Context, staticMap models.StaticMap, scale uint8, markerBytes map[string][]byte, sm *SphericalMercator) error {
 	// Process polygons
 	for _, polygon := range staticMap.Polygons {
 		if len(polygon.Path) == 0 {
@@ -262,7 +285,12 @@ func GenerateStaticMapNative(staticMap models.StaticMap, basePath, path string, 
 		// Load and resize if not cached
 		if markerImg == nil {
 			var err error
-			markerImg, err = loadImage(markerPath)
+			key := getMarkerPath(marker)
+			if b, ok := markerBytes[key]; ok {
+				markerImg, err = decodeImage(b)
+			} else {
+				markerImg, err = loadImage(markerPath)
+			}
 			if err != nil {
 				continue // Skip markers that can't be loaded
 			}
@@ -287,7 +315,7 @@ func GenerateStaticMapNative(staticMap models.StaticMap, basePath, path string, 
 		dc.DrawImage(markerImg, drawX, drawY)
 	}
 
-	return saveImage(path, dc.Image())
+	return nil
 }
 
 // GenerateMultiStaticMapNative combines multiple static maps into a grid using native Go.


### PR DESCRIPTION
## Summary

Closes a class of races and file-read failures in `/staticmap` and `/multistaticmap` by routing image data through memory instead of re-reading intermediate files from disk.

### Fixes

- **Stale cache-index basePath bug** — `HasStaticMap(basePath)=true` could falsely claim a deleted base existed. The handler no longer consults the cache index for base existence; it reads the base once into `[]byte` and regenerates on ENOENT.
- **Per-request TTL nuking shared bases** — the expiry queue no longer enqueues `basePath`. Base lifetime is owned by `CacheCleaner`'s age-based sweep.
- **Concurrent sibling base renders** — a new `baseSfg singleflight.Group` keyed on `basePath` deduplicates base rendering for sibling requests that share viewport but differ in overlays.
- **CacheCleaner-vs-draw marker race** — `downloadMarkerBytes` holds marker bytes in memory through `drawOverlays`, so a sweep between download and draw cannot fail the request.
- **Component deletion mid-stitch** — multi handler composes from `[][]byte` returned by `GenerateStaticMap`, never re-reading component files.
- **Write-vs-serve TOCTOU** — responses are served from in-memory bytes when available, so deletion of the final file between atomic write and HTTP serve is harmless.

### Out of scope (documented)

- `Cache/Tile/*` is still read from disk inside the tile-stitch stage. Mitigated by fresh mtime + `loadImageWithRetry`'s redownload callback.

## Plan

Full plan committed in `docs/superpowers/plans/2026-04-15-bytes-first-staticmap.md`. 10 commits following TDD; race tests for base deletion, sibling singleflight, marker deletion, and component deletion all pass.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] Race tests: `TestBaseDeletedBetweenCallsDoesNotError`, `TestConcurrentSiblingBaseSingleflight`, `TestMarkerDeletedBetweenDownloadAndDrawDoesNotFail`, `TestComposeMultiStaticMapBytes_ImmuneToComponentDeletion`
- [ ] **Production smoke** (owner): deploy branch, POST `/staticmap/poracle-weather` with `pregenerate=true&ttl=300`, then delete the base file out from under concurrent requests — should no longer 500.
- [ ] Verify the pre-existing `renderer.TestWorkerHangIsKilledOnContextDeadline -race` failure is still orthogonal (present on base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)