### PR TITLE
fix: basePath races, scale/ratio rendering, expiry queue rewrite

### DIFF
--- a/rampardos-render-worker/render-worker.js
+++ b/rampardos-render-worker/render-worker.js
@@ -44,6 +44,7 @@ const args = require("node:util").parseArgs({
     "mbtiles":    { type: "string" },
     "styles-dir": { type: "string" },
     "fonts-dir":  { type: "string" },
+    "ratio":      { type: "string" },
   },
 }).values;
 
@@ -145,8 +146,9 @@ try {
     "SELECT tile_data FROM tiles WHERE zoom_level = ? AND tile_column = ? AND tile_row = ?"
   );
 
+  const ratio = parseInt(args["ratio"] || "1", 10) || 1;
   map = new mbgl.Map({
-    ratio: 1,
+    ratio: ratio,
     request: (req, callback) => {
       try {
         const url = req.url;

--- a/rampardos/internal/handlers/common.go
+++ b/rampardos/internal/handlers/common.go
@@ -21,19 +21,16 @@ import (
 const nocacheBaseTTLFloor = 30 * time.Second
 
 // enqueueWithBase schedules path and, when distinct, basePath for
-// deletion after ttl. Used by the static-map and multi-static-map
-// handlers to honour the caller's TTL for the shared base — the
-// old behaviour of leaving basePath for CacheCleaner's ~7-day sweep
-// caused bases to persist orders of magnitude longer than the
-// caller asked for.
+// deletion after ttl. For single-path callers (e.g. multi handler
+// whose composite has no shared base), pass path == basePath.
 func enqueueWithBase(q *services.ExpiryQueue, ttl time.Duration, path, basePath string) {
 	if q == nil {
 		return
 	}
 	if path != basePath {
-		q.Add(ttl, nil, path, basePath)
+		q.Add(ttl, path, basePath)
 	} else {
-		q.Add(ttl, nil, path)
+		q.Add(ttl, path)
 	}
 }
 

--- a/rampardos/internal/handlers/common.go
+++ b/rampardos/internal/handlers/common.go
@@ -7,7 +7,35 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
+
+	"github.com/lenisko/rampardos/internal/services"
 )
+
+// nocacheBaseTTLFloor is the minimum TTL applied to a shared basePath
+// when the owning request was nocache. Without this floor, a burst of
+// concurrent requests at the same viewport (e.g. mass weather alerts)
+// would each regenerate the base. The floor lets the render be reused
+// across the burst without persisting for days. Tiles are already
+// cached, so re-stitching after the floor expires is cheap.
+const nocacheBaseTTLFloor = 30 * time.Second
+
+// enqueueWithBase schedules path and, when distinct, basePath for
+// deletion after ttl. Used by the static-map and multi-static-map
+// handlers to honour the caller's TTL for the shared base — the
+// old behaviour of leaving basePath for CacheCleaner's ~7-day sweep
+// caused bases to persist orders of magnitude longer than the
+// caller asked for.
+func enqueueWithBase(q *services.ExpiryQueue, ttl time.Duration, path, basePath string) {
+	if q == nil {
+		return
+	}
+	if path != basePath {
+		q.Add(ttl, nil, path, basePath)
+	} else {
+		q.Add(ttl, nil, path)
+	}
+}
 
 // knownDirs caches directories that have been created to avoid repeated syscalls
 var knownDirs sync.Map

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -217,23 +217,10 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		ensureDir(filepath.Dir(path))
 		err := utils.GenerateMultiStaticMap(multiStaticMap, path)
 
-		// Overlay-baked component finals have no reuse value; delete
-		// immediately under nocache. Each component's basePath gets a
-		// short floor TTL so sibling bursts (e.g. mass weather alerts
-		// at the same location) share one render; re-stitching from
-		// cached tiles after the floor is cheap.
-		if skipCache {
-			for _, sm := range mapsToGenerate {
-				smPath := sm.Path()
-				basePath := sm.BasePath()
-				if smPath != basePath {
-					os.Remove(smPath)
-				}
-				if services.GlobalExpiryQueue != nil {
-					services.GlobalExpiryQueue.Add(nocacheBaseTTLFloor, nil, basePath)
-				}
-			}
-		}
+		// Component cleanup is handled by each component's
+		// GenerateStaticMap call (which enqueues per its own
+		// nocache/TTL intent). Nothing to do here — the extend-
+		// only expiry queue ensures the longest intent wins.
 
 		return nil, err
 	})
@@ -252,7 +239,12 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 	if skipCache {
 		slog.Debug("Served multi-static map (nocache)", "file", filepath.Base(path), "maps", mapCount, "duration", duration)
 		serveFile(w, r, path)
-		os.Remove(path)
+		// Enqueue with floor instead of os.Remove — a concurrent
+		// pregenerate+ttl request may have just handed this URL to
+		// its subscribers; an immediate delete would 404 them.
+		if services.GlobalExpiryQueue != nil {
+			services.GlobalExpiryQueue.Add(nocacheBaseTTLFloor, nil, path)
+		}
 		return
 	}
 
@@ -261,6 +253,8 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 
 	if ttlSeconds > 0 && services.GlobalExpiryQueue != nil {
 		services.GlobalExpiryQueue.Add(time.Duration(ttlSeconds)*time.Second, nil, path)
+	} else if services.GlobalExpiryQueue != nil {
+		services.GlobalExpiryQueue.Add(services.OwnedThreshold, nil, path)
 	}
 }
 

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -135,16 +135,10 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	// Check if cached (use cache index first, then filesystem)
 	cached := false
 	if !skipCache {
-		if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasMultiStaticMap(path) {
+		if _, err := os.Stat(path); err == nil {
 			cached = true
-		} else if _, err := os.Stat(path); err == nil {
-			cached = true
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.AddMultiStaticMap(path)
-			}
 		}
 	}
 
@@ -252,19 +246,11 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if services.GlobalCacheIndex != nil {
-		services.GlobalCacheIndex.AddMultiStaticMap(path)
-	}
 	slog.Debug("Served multi-static map (generated)", "file", filepath.Base(path), "maps", mapCount, "duration", duration, "ttl", ttlSeconds)
 	h.generateResponse(w, r, multiStaticMap, path)
 
 	if ttlSeconds > 0 && services.GlobalExpiryQueue != nil {
-		cleanupIndex := func() {
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.RemoveMultiStaticMap(path)
-			}
-		}
-		services.GlobalExpiryQueue.Add(time.Duration(ttlSeconds)*time.Second, cleanupIndex, path)
+		services.GlobalExpiryQueue.Add(time.Duration(ttlSeconds)*time.Second, nil, path)
 	}
 }
 

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -188,7 +188,17 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 			wg.Add(1)
 			go func(sm models.StaticMap) {
 				defer wg.Done()
-				sem <- struct{}{}
+				// Respect client disconnect / request timeout while
+				// waiting for a sem slot. Without this escape, queued
+				// goroutines sit blocked after ctx is cancelled, then
+				// wake up and redundantly call into GenerateStaticMap
+				// only to fail fast. Cheaper to short-circuit now.
+				select {
+				case sem <- struct{}{}:
+				case <-r.Context().Done():
+					errOnce.Do(func() { genErr = r.Context().Err() })
+					return
+				}
 				defer func() { <-sem }()
 
 				if err := h.staticMapHandler.GenerateStaticMap(r.Context(), sm, componentOpts); err != nil {

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -217,10 +217,7 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		ensureDir(filepath.Dir(path))
 		err := utils.GenerateMultiStaticMap(multiStaticMap, path)
 
-		// Component cleanup is handled by each component's
-		// GenerateStaticMap call (which enqueues per its own
-		// nocache/TTL intent). Nothing to do here — the extend-
-		// only expiry queue ensures the longest intent wins.
+		// Component files are enqueued by each GenerateStaticMap call.
 
 		return nil, err
 	})
@@ -239,22 +236,18 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 	if skipCache {
 		slog.Debug("Served multi-static map (nocache)", "file", filepath.Base(path), "maps", mapCount, "duration", duration)
 		serveFile(w, r, path)
-		// Enqueue with floor instead of os.Remove — a concurrent
-		// pregenerate+ttl request may have just handed this URL to
-		// its subscribers; an immediate delete would 404 them.
-		if services.GlobalExpiryQueue != nil {
-			services.GlobalExpiryQueue.Add(nocacheBaseTTLFloor, nil, path)
-		}
+		// nocacheBaseTTLFloor protects in-flight pregenerate+ttl subscribers.
+		enqueueWithBase(services.GlobalExpiryQueue, nocacheBaseTTLFloor, path, path)
 		return
 	}
 
 	slog.Debug("Served multi-static map (generated)", "file", filepath.Base(path), "maps", mapCount, "duration", duration, "ttl", ttlSeconds)
 	h.generateResponse(w, r, multiStaticMap, path)
 
-	if ttlSeconds > 0 && services.GlobalExpiryQueue != nil {
-		services.GlobalExpiryQueue.Add(time.Duration(ttlSeconds)*time.Second, nil, path)
-	} else if services.GlobalExpiryQueue != nil {
-		services.GlobalExpiryQueue.Add(services.OwnedThreshold, nil, path)
+	if ttlSeconds > 0 {
+		enqueueWithBase(services.GlobalExpiryQueue, time.Duration(ttlSeconds)*time.Second, path, path)
+	} else {
+		enqueueWithBase(services.GlobalExpiryQueue, services.OwnedThreshold, path, path)
 	}
 }
 

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -213,13 +213,21 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		ensureDir(filepath.Dir(path))
 		err := utils.GenerateMultiStaticMap(multiStaticMap, path)
 
-		// For nocache, remove only each component's final path. The
-		// shared basePath is not this request's to delete — siblings
-		// may be rendering against it concurrently, and CacheCleaner
-		// age-evicts it on its own schedule.
+		// For nocache, overlay-baked component finals are deleted now.
+		// Each component's basePath gets a short floor TTL so sibling
+		// bursts (e.g. mass weather alerts at the same location) share
+		// one render. Re-stitching from cached tiles after the floor
+		// is cheap.
 		if skipCache {
 			for _, sm := range mapsToGenerate {
-				os.Remove(sm.Path())
+				smPath := sm.Path()
+				basePath := sm.BasePath()
+				if smPath != basePath {
+					os.Remove(smPath)
+				}
+				if services.GlobalExpiryQueue != nil {
+					services.GlobalExpiryQueue.Add(nocacheBaseTTLFloor, nil, basePath)
+				}
 			}
 		}
 

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -213,15 +213,13 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		ensureDir(filepath.Dir(path))
 		err := utils.GenerateMultiStaticMap(multiStaticMap, path)
 
-		// For nocache, clean up component files now that they've been
-		// combined into the final image.
+		// For nocache, remove only each component's final path. The
+		// shared basePath is not this request's to delete — siblings
+		// may be rendering against it concurrently, and CacheCleaner
+		// age-evicts it on its own schedule.
 		if skipCache {
 			for _, sm := range mapsToGenerate {
 				os.Remove(sm.Path())
-				bp := sm.BasePath()
-				if bp != sm.Path() {
-					os.Remove(bp)
-				}
 			}
 		}
 

--- a/rampardos/internal/handlers/multi_static_map.go
+++ b/rampardos/internal/handlers/multi_static_map.go
@@ -207,11 +207,11 @@ func (h *MultiStaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Req
 		ensureDir(filepath.Dir(path))
 		err := utils.GenerateMultiStaticMap(multiStaticMap, path)
 
-		// For nocache, overlay-baked component finals are deleted now.
-		// Each component's basePath gets a short floor TTL so sibling
-		// bursts (e.g. mass weather alerts at the same location) share
-		// one render. Re-stitching from cached tiles after the floor
-		// is cheap.
+		// Overlay-baked component finals have no reuse value; delete
+		// immediately under nocache. Each component's basePath gets a
+		// short floor TTL so sibling bursts (e.g. mass weather alerts
+		// at the same location) share one render; re-stitching from
+		// cached tiles after the floor is cheap.
 		if skipCache {
 			for _, sm := range mapsToGenerate {
 				smPath := sm.Path()

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -36,7 +36,8 @@ type StaticMapHandler struct {
 	statsController   *services.StatsController
 	stylesController  stylesControllerGetExternal
 	sphericalMercator *utils.SphericalMercator
-	sfg               singleflight.Group // dedup concurrent generates for same path
+	sfg               singleflight.Group // dedup concurrent generates for same final path
+	baseSfg           singleflight.Group // dedup concurrent base renders for same basePath
 
 	// Function-valued hooks. Production wiring in NewStaticMapHandler
 	// sets these to the real methods below; tests override them to
@@ -160,11 +161,7 @@ func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap mode
 				return nil, nil
 			}
 		}
-		baseExists := false
-		if _, err := os.Stat(basePath); err == nil {
-			baseExists = true
-		}
-		return nil, h.generateStaticMap(ctx, path, basePath, baseExists, staticMap)
+		return nil, h.generateStaticMap(ctx, path, basePath, staticMap)
 	})
 	if err != nil {
 		return err
@@ -172,21 +169,17 @@ func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap mode
 
 	// Apply TTL or nocache cleanup to component files.
 	if opts.NoCache {
-		// Caller will read the file then we clean up.
-		// Defer cleanup so the multistaticmap combiner can read it first.
-		// The caller (multistaticmap handler) is responsible for calling
-		// CleanupComponentMaps after combining.
+		// Caller reads the file then cleans up.
 	} else if opts.TTL > 0 && services.GlobalExpiryQueue != nil {
 		cleanupIndex := func() {
 			if services.GlobalCacheIndex != nil {
 				services.GlobalCacheIndex.RemoveStaticMap(path)
 			}
 		}
-		if path != basePath {
-			services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path, basePath)
-		} else {
-			services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path)
-		}
+		// basePath is shared state governed by CacheCleaner age
+		// eviction; do not enqueue it alongside a single caller's
+		// TTL or siblings will suffer a premature base deletion.
+		services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path)
 	}
 
 	return nil
@@ -264,21 +257,10 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 	// singleflight. Two poracle webhooks for the same spawn arriving
 	// simultaneously will only generate once.
 	_, genErr, _ := h.sfg.Do(path, func() (any, error) {
-		// Double-check cache inside singleflight.
 		if _, err := os.Stat(path); err == nil {
 			return nil, nil
 		}
-
-		baseExists := false
-		if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasStaticMap(basePath) {
-			baseExists = true
-		} else if _, err := os.Stat(basePath); err == nil {
-			baseExists = true
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.AddStaticMap(basePath)
-			}
-		}
-		return nil, h.generateStaticMap(r.Context(), path, basePath, baseExists, staticMap)
+		return nil, h.generateStaticMap(r.Context(), path, basePath, staticMap)
 	})
 
 	if genErr != nil {
@@ -299,9 +281,7 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 		slog.Debug("Served static map (nocache)", "file", filepath.Base(path), "duration", duration)
 		serveFile(w, r, path)
 		os.Remove(path)
-		if path != basePath {
-			os.Remove(basePath)
-		}
+		// basePath is shared state; CacheCleaner age-evicts it.
 		return
 	}
 
@@ -321,11 +301,10 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 				services.GlobalCacheIndex.RemoveStaticMap(path)
 			}
 		}
-		if path != basePath {
-			services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path, basePath)
-		} else {
-			services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
-		}
+		// basePath is shared state governed by CacheCleaner age
+		// eviction; do not enqueue it alongside a single caller's
+		// TTL or siblings will suffer a premature base deletion.
+		services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
 	}
 }
 
@@ -362,18 +341,37 @@ func (h *StaticMapHandler) handlePregeneratedRequest(w http.ResponseWriter, r *h
 	h.handleRequest(w, r, staticMap)
 }
 
-func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath string, baseExists bool, staticMap models.StaticMap) error {
-	// Ensure cache directory exists (cached check)
+// ensureBase renders basePath if it's missing on disk. Concurrent
+// callers for the same basePath are deduplicated via baseSfg, so
+// sibling requests (same viewport, different overlays) do not
+// duplicate base rendering. The cache index is not consulted — a
+// stale entry could falsely claim the base existed while it had
+// been removed by CacheCleaner or an external actor, leading the
+// subsequent read to fail.
+//
+// Singleflight key correctness: basePath == BasePath() ==
+// hash(WithoutDrawables()), so two callers share a slot iff their
+// base-rendering inputs (style/lat/lon/zoom/w/h/scale/bearing/pitch/
+// format) are identical. Base generation reads none of Markers,
+// Polygons, or Circles, so merging the renders is safe.
+func (h *StaticMapHandler) ensureBase(ctx context.Context, staticMap models.StaticMap, basePath string) error {
+	_, err, _ := h.baseSfg.Do(basePath, func() (any, error) {
+		if _, err := os.Stat(basePath); err == nil {
+			return nil, nil
+		}
+		return nil, h.generateBaseStaticMap(ctx, staticMap, basePath)
+	})
+	return err
+}
+
+func (h *StaticMapHandler) generateStaticMap(ctx context.Context, path, basePath string, staticMap models.StaticMap) error {
 	ensureDir(filepath.Dir(path))
 
-	hasDrawables := len(staticMap.Markers) > 0 || len(staticMap.Polygons) > 0 || len(staticMap.Circles) > 0
-
-	// Generate base if needed
-	if !baseExists {
-		if err := h.generateBaseStaticMap(ctx, staticMap, basePath); err != nil {
-			return err
-		}
+	if err := h.ensureBase(ctx, staticMap, basePath); err != nil {
+		return err
 	}
+
+	hasDrawables := len(staticMap.Markers) > 0 || len(staticMap.Polygons) > 0 || len(staticMap.Circles) > 0
 
 	// If no drawables, just use base
 	if !hasDrawables {

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -380,6 +380,8 @@ func (h *StaticMapHandler) generateBaseStaticMap(ctx context.Context, staticMap 
 	if extStyle == nil {
 		// Local style: fractional zoom → viewport render (native float zoom).
 		// Integer zoom → tile stitching (cacheable via Cache/Tile).
+		// Scale>1 uses per-scale worker pools (ratio=scale) so tiles
+		// have correct geographic extent; stitching works normally.
 		if isFractional(staticMap.Zoom) {
 			return h.generateBaseStaticMapFromAPIFn(ctx, staticMap, basePath)
 		}

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -167,11 +167,14 @@ func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap mode
 		return err
 	}
 
-	// Apply TTL or nocache cleanup to component files.
+	// Every generation enqueues its intent so the extend-only queue
+	// resolves concurrent nocache vs TTL vs cached races correctly.
 	if opts.NoCache {
-		// Caller reads the file then cleans up.
+		enqueueWithBase(services.GlobalExpiryQueue, nocacheBaseTTLFloor, path, basePath)
 	} else if opts.TTL > 0 {
 		enqueueWithBase(services.GlobalExpiryQueue, opts.TTL, path, basePath)
+	} else {
+		enqueueWithBase(services.GlobalExpiryQueue, services.OwnedThreshold, path, basePath)
 	}
 
 	return nil
@@ -264,31 +267,27 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 	services.GlobalMetrics.RecordRequest("staticmap", staticMap.Style, false, duration)
 
 	if skipCache {
-		// nocache mode: serve the image directly and clean up temp
-		// files. No cache index entry, no disk footprint left behind.
-		// (pregenerate+nocache is already converted to TTL above.)
 		slog.Debug("Served static map (nocache)", "file", filepath.Base(path), "duration", duration)
 		serveFile(w, r, path)
-		// Overlay-baked artifact has no reuse value; delete now.
-		// Leave basePath with a short floor TTL so sibling burst
-		// requests at the same viewport can share the render.
-		if path != basePath {
-			os.Remove(path)
-		}
-		if services.GlobalExpiryQueue != nil {
-			services.GlobalExpiryQueue.Add(nocacheBaseTTLFloor, nil, basePath)
-		}
+		// Enqueue with the burst-sharing floor instead of os.Remove.
+		// A concurrent pregenerate+ttl request for the same hash may
+		// have told its subscribers to fetch the file later — an
+		// immediate delete would 404 them. The extend-only expiry
+		// queue ensures the longer TTL wins.
+		enqueueWithBase(services.GlobalExpiryQueue, nocacheBaseTTLFloor, path, basePath)
 		return
 	}
 
-	// Normal mode: keep on disk for cache.
 	slog.Debug("Served static map (generated)", "file", filepath.Base(path), "duration", duration, "ttl", ttlSeconds)
 	h.generateResponse(w, r, staticMap, path)
 
-	// If a TTL was requested, queue the file for deletion after the
-	// specified duration. A single background sweeper handles cleanup.
 	if ttlSeconds > 0 {
 		enqueueWithBase(services.GlobalExpiryQueue, time.Duration(ttlSeconds)*time.Second, path, basePath)
+	} else {
+		// No explicit TTL: mark as owned by CacheCleaner so a
+		// concurrent nocache request's short floor can't shorten
+		// this file's lifetime.
+		enqueueWithBase(services.GlobalExpiryQueue, services.OwnedThreshold, path, basePath)
 	}
 }
 

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -472,6 +472,13 @@ func (h *StaticMapHandler) generateBaseStaticMapFromTiles(ctx context.Context, s
 	if extStyle != nil {
 		hasScale = strings.Contains(extStyle.URL, "{@scale}") || strings.Contains(extStyle.URL, "{scale}")
 	}
+	// Local styles at scale>1 produce tiles at tilePixels*scale
+	// (e.g. 1024px for scale=2). The crop in GenerateBaseStaticMap
+	// must multiply offset and output dimensions by scale — the same
+	// path external scale-aware tiles use via hasScale.
+	if extStyle == nil && scale > 1 {
+		hasScale = true
+	}
 
 	// Generate tiles in parallel. Each tile is an independent download
 	// or render; parallelising cuts wall-clock time from N*latency to

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -179,20 +179,14 @@ func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap mode
 	if opts.NoCache {
 		// Caller reads the file then cleans up.
 	} else if opts.TTL > 0 && services.GlobalExpiryQueue != nil {
-		cleanupIndex := func() {
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.RemoveStaticMap(path)
-			}
-		}
 		// Enqueue path and basePath together so the base doesn't
-		// outlive the caller's requested TTL by days via CacheCleaner.
-		// The cache-index no longer tracks basePath, so enqueuing it
-		// can't produce the stale-lie 500 that motivated this class
-		// of fix.
+		// outlive the caller's requested TTL via CacheCleaner's
+		// default (~7 days). Re-stitching from cached tiles on a
+		// future request is cheap.
 		if path != basePath {
-			services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path, basePath)
+			services.GlobalExpiryQueue.Add(opts.TTL, nil, path, basePath)
 		} else {
-			services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path)
+			services.GlobalExpiryQueue.Add(opts.TTL, nil, path)
 		}
 	}
 
@@ -245,16 +239,13 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 		}
 	}
 
-	// Check if cached (use cache index first, then filesystem)
+	// Check if cached — os.Stat is authoritative. The prior cache
+	// index could outlive its on-disk file and serve a stale "true"
+	// that led to a 404 on the subsequent ServeFile.
 	cached := false
 	if !skipCache {
-		if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasStaticMap(path) {
+		if _, err := os.Stat(path); err == nil {
 			cached = true
-		} else if _, err := os.Stat(path); err == nil {
-			cached = true
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.AddStaticMap(path)
-			}
 		}
 	}
 
@@ -307,9 +298,6 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 	}
 
 	// Normal mode: keep on disk for cache.
-	if services.GlobalCacheIndex != nil {
-		services.GlobalCacheIndex.AddStaticMap(path)
-	}
 	slog.Debug("Served static map (generated)", "file", filepath.Base(path), "duration", duration, "ttl", ttlSeconds)
 	h.generateResponse(w, r, staticMap, path)
 
@@ -317,19 +305,13 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 	// specified duration. A single background sweeper handles cleanup.
 	if ttlSeconds > 0 && services.GlobalExpiryQueue != nil {
 		ttl := time.Duration(ttlSeconds) * time.Second
-		cleanupIndex := func() {
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.RemoveStaticMap(path)
-			}
-		}
 		// Enqueue path and basePath together so the base doesn't
 		// outlive the requested TTL via CacheCleaner's 7-day default.
-		// Re-stitching from tiles on the next request is cheap; the
-		// old stale-index lie that made this dangerous is gone.
+		// Re-stitching from tiles on the next request is cheap.
 		if path != basePath {
-			services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path, basePath)
+			services.GlobalExpiryQueue.Add(ttl, nil, path, basePath)
 		} else {
-			services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
+			services.GlobalExpiryQueue.Add(ttl, nil, path)
 		}
 	}
 }
@@ -616,18 +598,8 @@ func (h *StaticMapHandler) downloadMarkers(ctx context.Context, staticMap models
 		path := fmt.Sprintf("Cache/Marker/%s.%s", hash, format)
 		domain := extractDomain(marker.URL)
 
-		// Check cache index first (fast path)
-		if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasMarker(path) {
-			h.statsController.MarkerServed(false, path, domain)
-			continue
-		}
-
-		// Check filesystem
+		// Already cached on disk?
 		if _, err := os.Stat(path); err == nil {
-			// Add to cache index
-			if services.GlobalCacheIndex != nil {
-				services.GlobalCacheIndex.AddMarker(path)
-			}
 			h.statsController.MarkerServed(false, path, domain)
 			continue
 		}
@@ -651,36 +623,21 @@ func (h *StaticMapHandler) downloadMarkers(ctx context.Context, staticMap models
 			defer func() { <-sem }()
 
 			if err := services.DownloadFile(ctx, md.marker.URL, md.path, "", 0); err != nil {
-				// Try fallback
-				if md.marker.FallbackURL != "" {
-					fallbackHash := utils.PersistentHashString(md.marker.FallbackURL)
-					fallbackPath := fmt.Sprintf("Cache/Marker/%s.%s", fallbackHash, md.format)
-					fallbackDomain := extractDomain(md.marker.FallbackURL)
+				if md.marker.FallbackURL == "" {
+					return
+				}
+				fallbackHash := utils.PersistentHashString(md.marker.FallbackURL)
+				fallbackPath := fmt.Sprintf("Cache/Marker/%s.%s", fallbackHash, md.format)
+				fallbackDomain := extractDomain(md.marker.FallbackURL)
 
-					// Check if fallback exists
-					if services.GlobalCacheIndex != nil && services.GlobalCacheIndex.HasMarker(fallbackPath) {
-						h.statsController.MarkerServed(false, fallbackPath, fallbackDomain)
-						return
-					}
-					if _, err := os.Stat(fallbackPath); err == nil {
-						if services.GlobalCacheIndex != nil {
-							services.GlobalCacheIndex.AddMarker(fallbackPath)
-						}
-						h.statsController.MarkerServed(false, fallbackPath, fallbackDomain)
-						return
-					}
-
-					if err := services.DownloadFile(ctx, md.marker.FallbackURL, fallbackPath, "", 0); err == nil {
-						if services.GlobalCacheIndex != nil {
-							services.GlobalCacheIndex.AddMarker(fallbackPath)
-						}
-						h.statsController.MarkerServed(true, fallbackPath, fallbackDomain)
-					}
+				if _, err := os.Stat(fallbackPath); err == nil {
+					h.statsController.MarkerServed(false, fallbackPath, fallbackDomain)
+					return
+				}
+				if err := services.DownloadFile(ctx, md.marker.FallbackURL, fallbackPath, "", 0); err == nil {
+					h.statsController.MarkerServed(true, fallbackPath, fallbackDomain)
 				}
 			} else {
-				if services.GlobalCacheIndex != nil {
-					services.GlobalCacheIndex.AddMarker(md.path)
-				}
 				h.statsController.MarkerServed(true, md.path, md.domain)
 			}
 		}(md)

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -143,14 +143,6 @@ type GenerateOpts struct {
 	TTL        time.Duration // if > 0, queue files for deletion after this duration
 }
 
-// nocacheBaseTTLFloor is the minimum TTL applied to a shared basePath
-// when the owning request was nocache. Without this floor, a burst of
-// concurrent requests at the same viewport (e.g. mass weather alerts)
-// would each regenerate the base. The floor lets the render be reused
-// across the burst without persisting for days. Tiles are already
-// cached, so re-stitching after the floor expires is cheap.
-const nocacheBaseTTLFloor = 30 * time.Second
-
 // GenerateStaticMap generates a static map (used by MultiStaticMapHandler).
 // Concurrent requests for the same map are deduplicated via singleflight.
 func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap models.StaticMap, opts GenerateOpts) error {
@@ -178,16 +170,8 @@ func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap mode
 	// Apply TTL or nocache cleanup to component files.
 	if opts.NoCache {
 		// Caller reads the file then cleans up.
-	} else if opts.TTL > 0 && services.GlobalExpiryQueue != nil {
-		// Enqueue path and basePath together so the base doesn't
-		// outlive the caller's requested TTL via CacheCleaner's
-		// default (~7 days). Re-stitching from cached tiles on a
-		// future request is cheap.
-		if path != basePath {
-			services.GlobalExpiryQueue.Add(opts.TTL, nil, path, basePath)
-		} else {
-			services.GlobalExpiryQueue.Add(opts.TTL, nil, path)
-		}
+	} else if opts.TTL > 0 {
+		enqueueWithBase(services.GlobalExpiryQueue, opts.TTL, path, basePath)
 	}
 
 	return nil
@@ -303,16 +287,8 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 
 	// If a TTL was requested, queue the file for deletion after the
 	// specified duration. A single background sweeper handles cleanup.
-	if ttlSeconds > 0 && services.GlobalExpiryQueue != nil {
-		ttl := time.Duration(ttlSeconds) * time.Second
-		// Enqueue path and basePath together so the base doesn't
-		// outlive the requested TTL via CacheCleaner's 7-day default.
-		// Re-stitching from tiles on the next request is cheap.
-		if path != basePath {
-			services.GlobalExpiryQueue.Add(ttl, nil, path, basePath)
-		} else {
-			services.GlobalExpiryQueue.Add(ttl, nil, path)
-		}
+	if ttlSeconds > 0 {
+		enqueueWithBase(services.GlobalExpiryQueue, time.Duration(ttlSeconds)*time.Second, path, basePath)
 	}
 }
 

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -143,6 +143,14 @@ type GenerateOpts struct {
 	TTL        time.Duration // if > 0, queue files for deletion after this duration
 }
 
+// nocacheBaseTTLFloor is the minimum TTL applied to a shared basePath
+// when the owning request was nocache. Without this floor, a burst of
+// concurrent requests at the same viewport (e.g. mass weather alerts)
+// would each regenerate the base. The floor lets the render be reused
+// across the burst without persisting for days. Tiles are already
+// cached, so re-stitching after the floor expires is cheap.
+const nocacheBaseTTLFloor = 30 * time.Second
+
 // GenerateStaticMap generates a static map (used by MultiStaticMapHandler).
 // Concurrent requests for the same map are deduplicated via singleflight.
 func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap models.StaticMap, opts GenerateOpts) error {
@@ -176,10 +184,16 @@ func (h *StaticMapHandler) GenerateStaticMap(ctx context.Context, staticMap mode
 				services.GlobalCacheIndex.RemoveStaticMap(path)
 			}
 		}
-		// basePath is shared state governed by CacheCleaner age
-		// eviction; do not enqueue it alongside a single caller's
-		// TTL or siblings will suffer a premature base deletion.
-		services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path)
+		// Enqueue path and basePath together so the base doesn't
+		// outlive the caller's requested TTL by days via CacheCleaner.
+		// The cache-index no longer tracks basePath, so enqueuing it
+		// can't produce the stale-lie 500 that motivated this class
+		// of fix.
+		if path != basePath {
+			services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path, basePath)
+		} else {
+			services.GlobalExpiryQueue.Add(opts.TTL, cleanupIndex, path)
+		}
 	}
 
 	return nil
@@ -280,8 +294,15 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 		// (pregenerate+nocache is already converted to TTL above.)
 		slog.Debug("Served static map (nocache)", "file", filepath.Base(path), "duration", duration)
 		serveFile(w, r, path)
-		os.Remove(path)
-		// basePath is shared state; CacheCleaner age-evicts it.
+		// Overlay-baked artifact has no reuse value; delete now.
+		// Leave basePath with a short floor TTL so sibling burst
+		// requests at the same viewport can share the render.
+		if path != basePath {
+			os.Remove(path)
+		}
+		if services.GlobalExpiryQueue != nil {
+			services.GlobalExpiryQueue.Add(nocacheBaseTTLFloor, nil, basePath)
+		}
 		return
 	}
 
@@ -301,10 +322,15 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 				services.GlobalCacheIndex.RemoveStaticMap(path)
 			}
 		}
-		// basePath is shared state governed by CacheCleaner age
-		// eviction; do not enqueue it alongside a single caller's
-		// TTL or siblings will suffer a premature base deletion.
-		services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
+		// Enqueue path and basePath together so the base doesn't
+		// outlive the requested TTL via CacheCleaner's 7-day default.
+		// Re-stitching from tiles on the next request is cheap; the
+		// old stale-index lie that made this dangerous is gone.
+		if path != basePath {
+			services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path, basePath)
+		} else {
+			services.GlobalExpiryQueue.Add(ttl, cleanupIndex, path)
+		}
 	}
 }
 

--- a/rampardos/internal/handlers/static_map.go
+++ b/rampardos/internal/handlers/static_map.go
@@ -269,11 +269,7 @@ func (h *StaticMapHandler) handleRequest(w http.ResponseWriter, r *http.Request,
 	if skipCache {
 		slog.Debug("Served static map (nocache)", "file", filepath.Base(path), "duration", duration)
 		serveFile(w, r, path)
-		// Enqueue with the burst-sharing floor instead of os.Remove.
-		// A concurrent pregenerate+ttl request for the same hash may
-		// have told its subscribers to fetch the file later — an
-		// immediate delete would 404 them. The extend-only expiry
-		// queue ensures the longer TTL wins.
+		// nocacheBaseTTLFloor protects in-flight pregenerate+ttl subscribers.
 		enqueueWithBase(services.GlobalExpiryQueue, nocacheBaseTTLFloor, path, basePath)
 		return
 	}

--- a/rampardos/internal/handlers/static_map_race_test.go
+++ b/rampardos/internal/handlers/static_map_race_test.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lenisko/rampardos/internal/models"
+	"github.com/lenisko/rampardos/internal/utils"
+)
+
+// raceFakePNG returns a valid 1x1 PNG for tests.
+func raceFakePNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// raceTestStaticMap is a stable StaticMap whose BasePath is
+// deterministic across goroutines in a test.
+func raceTestStaticMap() models.StaticMap {
+	return models.StaticMap{
+		Style:     "local",
+		Latitude:  51.5,
+		Longitude: 0.0,
+		Zoom:      14,
+		Width:     256,
+		Height:    256,
+	}
+}
+
+// raceTestHandler builds a minimal StaticMapHandler whose base
+// generators route through renderFn. The "local" style means
+// generateBaseStaticMap takes the tiles branch at integer zoom;
+// renderFn is wired into both tile and API hooks for safety.
+func raceTestHandler(t *testing.T, renderFn func(ctx context.Context, sm models.StaticMap, basePath string) error) (*StaticMapHandler, func()) {
+	t.Helper()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	h := &StaticMapHandler{
+		stylesController:  stubStylesController{ext: nil},
+		sphericalMercator: utils.NewSphericalMercator(),
+	}
+	h.generateBaseStaticMapFromTilesFn = func(ctx context.Context, sm models.StaticMap, basePath string, _ *models.Style) error {
+		return renderFn(ctx, sm, basePath)
+	}
+	h.generateBaseStaticMapFromAPIFn = renderFn
+	h.logExternalViewportApproxFn = func(sm models.StaticMap) {}
+
+	return h, func() { _ = os.Chdir(oldDir) }
+}
+
+// TestEnsureBaseDeletedBetweenCallsDoesNotError locks in the stale-
+// index-removed invariant: deleting basePath externally between
+// calls must trigger a fresh render, not a 500 or a skipped render.
+func TestEnsureBaseDeletedBetweenCallsDoesNotError(t *testing.T) {
+	var renders atomic.Int32
+	renderFn := func(ctx context.Context, sm models.StaticMap, basePath string) error {
+		renders.Add(1)
+		if err := os.MkdirAll(filepath.Dir(basePath), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(basePath, raceFakePNG(t), 0o644)
+	}
+	h, cleanup := raceTestHandler(t, renderFn)
+	defer cleanup()
+
+	sm := raceTestStaticMap()
+	basePath := sm.BasePath()
+	ctx := context.Background()
+
+	if err := h.ensureBase(ctx, sm, basePath); err != nil {
+		t.Fatalf("first ensureBase: %v", err)
+	}
+	if got := renders.Load(); got != 1 {
+		t.Fatalf("expected 1 render after first call, got %d", got)
+	}
+	if _, err := os.Stat(basePath); err != nil {
+		t.Fatalf("expected persisted base: %v", err)
+	}
+
+	if err := os.Remove(basePath); err != nil {
+		t.Fatalf("remove base: %v", err)
+	}
+
+	if err := h.ensureBase(ctx, sm, basePath); err != nil {
+		t.Fatalf("ensureBase after delete: %v", err)
+	}
+	if got := renders.Load(); got != 2 {
+		t.Fatalf("expected 2 renders after re-trigger, got %d", got)
+	}
+}
+
+// TestEnsureBaseSingleflightDedupesSiblings locks in the baseSfg
+// singleflight behaviour: N concurrent callers for the same basePath
+// trigger exactly one render.
+//
+// Determinism: the render fn blocks on a gate so the singleflight
+// leader cannot release its slot before followers arrive. Without
+// the gate, the leader could complete synchronously and later
+// goroutines would enter Do after the slot was released, producing
+// a "renders == 1" by luck rather than by correctness.
+func TestEnsureBaseSingleflightDedupesSiblings(t *testing.T) {
+	const N = 8
+	var renders atomic.Int32
+	reached := make(chan struct{}, N+1)
+	gate := make(chan struct{})
+
+	renderFn := func(ctx context.Context, sm models.StaticMap, basePath string) error {
+		renders.Add(1)
+		reached <- struct{}{}
+		<-gate
+		if err := os.MkdirAll(filepath.Dir(basePath), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(basePath, raceFakePNG(t), 0o644)
+	}
+	h, cleanup := raceTestHandler(t, renderFn)
+	defer cleanup()
+
+	sm := raceTestStaticMap()
+	basePath := sm.BasePath()
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := h.ensureBase(ctx, sm, basePath); err != nil {
+				t.Errorf("ensureBase: %v", err)
+			}
+		}()
+	}
+
+	<-reached
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	if got := renders.Load(); got != 1 {
+		t.Fatalf("expected 1 base render for %d concurrent callers, got %d", N, got)
+	}
+	if extra := len(reached); extra != 0 {
+		t.Fatalf("expected no extra render fn entries, got %d", extra)
+	}
+}

--- a/rampardos/internal/handlers/static_map_race_test.go
+++ b/rampardos/internal/handlers/static_map_race_test.go
@@ -115,14 +115,24 @@ func TestEnsureBaseDeletedBetweenCallsDoesNotError(t *testing.T) {
 // singleflight behaviour: N concurrent callers for the same basePath
 // trigger exactly one render.
 //
-// Determinism: the render fn blocks on a gate so the singleflight
-// leader cannot release its slot before followers arrive. Without
-// the gate, the leader could complete synchronously and later
-// goroutines would enter Do after the slot was released, producing
-// a "renders == 1" by luck rather than by correctness.
+// Determinism in two stages:
+//  1. Each goroutine signals `started` immediately before calling
+//     ensureBase. Draining N signals proves all N are live.
+//  2. The render fn blocks on `gate` so the leader cannot release
+//     its singleflight slot before followers arrive. We read one
+//     `reached` signal to confirm the leader is inside the render
+//     fn, then briefly yield for the N-1 followers to suspend
+//     inside baseSfg.Do (the only call between "started" and the
+//     render fn for them), then release the gate.
+//
+// singleflight.Group exposes no "pending count" so the final yield
+// is necessarily wall-clock, but the start barrier shrinks the
+// window it has to cover from "all goroutines must run" to just
+// "N-1 goroutines must enter Do" — a handful of instructions.
 func TestEnsureBaseSingleflightDedupesSiblings(t *testing.T) {
 	const N = 8
 	var renders atomic.Int32
+	started := make(chan struct{}, N)
 	reached := make(chan struct{}, N+1)
 	gate := make(chan struct{})
 
@@ -147,14 +157,18 @@ func TestEnsureBaseSingleflightDedupesSiblings(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			started <- struct{}{}
 			if err := h.ensureBase(ctx, sm, basePath); err != nil {
 				t.Errorf("ensureBase: %v", err)
 			}
 		}()
 	}
 
+	for i := 0; i < N; i++ {
+		<-started
+	}
 	<-reached
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	close(gate)
 	wg.Wait()
 

--- a/rampardos/internal/services/cache_cleaner.go
+++ b/rampardos/internal/services/cache_cleaner.go
@@ -277,7 +277,12 @@ func (cc *CacheCleaner) shouldRemove(info os.FileInfo, cutoff, dropCutoff time.T
 	return false
 }
 
-// removeFromCacheIndex removes a path from the appropriate cache index based on folder
+// removeFromCacheIndex removes a path from the appropriate cache index
+// based on folder. Cache/Tile is not indexed — the Tile branch had no
+// readers and was removed alongside HasTile/AddTile.
+//
+// StaticMulti must be checked first — "Cache/Static" is a prefix of
+// "Cache/StaticMulti", so the broader case would shadow it.
 func (cc *CacheCleaner) removeFromCacheIndex(path string) {
 	switch {
 	case strings.HasPrefix(cc.folder, "Cache/StaticMulti"):
@@ -286,7 +291,5 @@ func (cc *CacheCleaner) removeFromCacheIndex(path string) {
 		GlobalCacheIndex.RemoveStaticMap(path)
 	case strings.HasPrefix(cc.folder, "Cache/Marker"):
 		GlobalCacheIndex.RemoveMarker(path)
-	case strings.HasPrefix(cc.folder, "Cache/Tile"):
-		GlobalCacheIndex.RemoveTile(path)
 	}
 }

--- a/rampardos/internal/services/cache_cleaner.go
+++ b/rampardos/internal/services/cache_cleaner.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 )
@@ -193,13 +192,9 @@ func (cc *CacheCleaner) runOnce() {
 
 		path := filepath.Join(cc.folder, entry.Name())
 
-		// If dropAll, remove all files
 		if dropAll {
 			if err := os.Remove(path); err == nil {
 				count++
-				if GlobalCacheIndex != nil {
-					cc.removeFromCacheIndex(path)
-				}
 			}
 			continue
 		}
@@ -212,10 +207,6 @@ func (cc *CacheCleaner) runOnce() {
 		if cc.shouldRemove(info, cutoff, dropCutoff) {
 			if err := os.Remove(path); err == nil {
 				count++
-				// Remove from cache index
-				if GlobalCacheIndex != nil {
-					cc.removeFromCacheIndex(path)
-				}
 			}
 		}
 	}
@@ -277,19 +268,3 @@ func (cc *CacheCleaner) shouldRemove(info os.FileInfo, cutoff, dropCutoff time.T
 	return false
 }
 
-// removeFromCacheIndex removes a path from the appropriate cache index
-// based on folder. Cache/Tile is not indexed — the Tile branch had no
-// readers and was removed alongside HasTile/AddTile.
-//
-// StaticMulti must be checked first — "Cache/Static" is a prefix of
-// "Cache/StaticMulti", so the broader case would shadow it.
-func (cc *CacheCleaner) removeFromCacheIndex(path string) {
-	switch {
-	case strings.HasPrefix(cc.folder, "Cache/StaticMulti"):
-		GlobalCacheIndex.RemoveMultiStaticMap(path)
-	case strings.HasPrefix(cc.folder, "Cache/Static"):
-		GlobalCacheIndex.RemoveStaticMap(path)
-	case strings.HasPrefix(cc.folder, "Cache/Marker"):
-		GlobalCacheIndex.RemoveMarker(path)
-	}
-}

--- a/rampardos/internal/services/cache_cleaner.go
+++ b/rampardos/internal/services/cache_cleaner.go
@@ -195,6 +195,9 @@ func (cc *CacheCleaner) runOnce() {
 		if dropAll {
 			if err := os.Remove(path); err == nil {
 				count++
+				if GlobalExpiryQueue != nil {
+					GlobalExpiryQueue.Unown(path)
+				}
 			}
 			continue
 		}
@@ -207,6 +210,9 @@ func (cc *CacheCleaner) runOnce() {
 		if cc.shouldRemove(info, cutoff, dropCutoff) {
 			if err := os.Remove(path); err == nil {
 				count++
+				if GlobalExpiryQueue != nil {
+					GlobalExpiryQueue.Unown(path)
+				}
 			}
 		}
 	}

--- a/rampardos/internal/services/cache_index.go
+++ b/rampardos/internal/services/cache_index.go
@@ -13,17 +13,14 @@ type markerImageEntry struct {
 	image image.Image
 }
 
-// CacheIndex maintains an in-memory index of cached files to reduce
-// syscalls on the serve path. Tiles are not indexed — the HasTile /
-// AddTile plumbing had no readers and the map only grew for the
-// process lifetime.
+// CacheIndex holds an LRU cache of decoded+resized marker images. It
+// no longer tracks static-map / multi-static-map / marker file presence
+// — those "caches" just saved a sub-microsecond stat syscall and
+// introduced a latent failure mode when index entries outlived the
+// on-disk files (stale-lie 404 / silently-missing marker). The LRU
+// below, in contrast, saves real work (image decode plus bicubic
+// resize, millisecond-scale per marker).
 type CacheIndex struct {
-	staticMaps      map[string]struct{}
-	multiStaticMaps map[string]struct{}
-	markers         map[string]struct{}
-	mu              sync.RWMutex
-
-	// LRU cache for resized marker images (path+size -> image.Image)
 	markerImages    map[string]*list.Element
 	markerImagesLRU *list.List
 	markerImagesMax int
@@ -36,9 +33,6 @@ var GlobalCacheIndex *CacheIndex
 // NewCacheIndex creates a new cache index
 func NewCacheIndex() *CacheIndex {
 	return &CacheIndex{
-		staticMaps:      make(map[string]struct{}),
-		multiStaticMaps: make(map[string]struct{}),
-		markers:         make(map[string]struct{}),
 		markerImages:    make(map[string]*list.Element),
 		markerImagesLRU: list.New(),
 		markerImagesMax: 500, // Default, can be changed via SetMarkerImageCacheSize
@@ -50,7 +44,6 @@ func (c *CacheIndex) SetMarkerImageCacheSize(size int) {
 	c.markerImagesMu.Lock()
 	defer c.markerImagesMu.Unlock()
 	c.markerImagesMax = size
-	// Evict if over new limit
 	for c.markerImagesLRU.Len() > c.markerImagesMax {
 		c.evictOldestMarkerImageLocked()
 	}
@@ -63,7 +56,6 @@ func (c *CacheIndex) GetMarkerImage(path string, width, height int) (image.Image
 	defer c.markerImagesMu.Unlock()
 
 	if elem, ok := c.markerImages[key]; ok {
-		// Move to front (most recently used)
 		c.markerImagesLRU.MoveToFront(elem)
 		return elem.Value.(*markerImageEntry).image, true
 	}
@@ -76,18 +68,15 @@ func (c *CacheIndex) AddMarkerImage(path string, width, height int, img image.Im
 	c.markerImagesMu.Lock()
 	defer c.markerImagesMu.Unlock()
 
-	// Already exists? Move to front
 	if elem, ok := c.markerImages[key]; ok {
 		c.markerImagesLRU.MoveToFront(elem)
 		return
 	}
 
-	// Evict oldest if at capacity
 	if c.markerImagesLRU.Len() >= c.markerImagesMax {
 		c.evictOldestMarkerImageLocked()
 	}
 
-	// Add new entry
 	entry := &markerImageEntry{key: key, image: img}
 	elem := c.markerImagesLRU.PushFront(entry)
 	c.markerImages[key] = elem
@@ -109,70 +98,3 @@ func markerImageKey(path string, width, height int) string {
 func InitGlobalCacheIndex() {
 	GlobalCacheIndex = NewCacheIndex()
 }
-
-// HasStaticMap checks if a static map is in the cache index
-func (c *CacheIndex) HasStaticMap(path string) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	_, ok := c.staticMaps[path]
-	return ok
-}
-
-// AddStaticMap adds a static map to the cache index
-func (c *CacheIndex) AddStaticMap(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.staticMaps[path] = struct{}{}
-}
-
-// RemoveStaticMap removes a static map from the cache index
-func (c *CacheIndex) RemoveStaticMap(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.staticMaps, path)
-}
-
-// HasMultiStaticMap checks if a multi static map is in the cache index
-func (c *CacheIndex) HasMultiStaticMap(path string) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	_, ok := c.multiStaticMaps[path]
-	return ok
-}
-
-// AddMultiStaticMap adds a multi static map to the cache index
-func (c *CacheIndex) AddMultiStaticMap(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.multiStaticMaps[path] = struct{}{}
-}
-
-// RemoveMultiStaticMap removes a multi static map from the cache index
-func (c *CacheIndex) RemoveMultiStaticMap(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.multiStaticMaps, path)
-}
-
-// HasMarker checks if a marker is in the cache index
-func (c *CacheIndex) HasMarker(path string) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	_, ok := c.markers[path]
-	return ok
-}
-
-// AddMarker adds a marker to the cache index
-func (c *CacheIndex) AddMarker(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.markers[path] = struct{}{}
-}
-
-// RemoveMarker removes a marker from the cache index
-func (c *CacheIndex) RemoveMarker(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.markers, path)
-}
-

--- a/rampardos/internal/services/cache_index.go
+++ b/rampardos/internal/services/cache_index.go
@@ -13,12 +13,14 @@ type markerImageEntry struct {
 	image image.Image
 }
 
-// CacheIndex maintains an in-memory index of cached files to reduce syscalls
+// CacheIndex maintains an in-memory index of cached files to reduce
+// syscalls on the serve path. Tiles are not indexed — the HasTile /
+// AddTile plumbing had no readers and the map only grew for the
+// process lifetime.
 type CacheIndex struct {
 	staticMaps      map[string]struct{}
 	multiStaticMaps map[string]struct{}
 	markers         map[string]struct{}
-	tiles           map[string]struct{}
 	mu              sync.RWMutex
 
 	// LRU cache for resized marker images (path+size -> image.Image)
@@ -37,7 +39,6 @@ func NewCacheIndex() *CacheIndex {
 		staticMaps:      make(map[string]struct{}),
 		multiStaticMaps: make(map[string]struct{}),
 		markers:         make(map[string]struct{}),
-		tiles:           make(map[string]struct{}),
 		markerImages:    make(map[string]*list.Element),
 		markerImagesLRU: list.New(),
 		markerImagesMax: 500, // Default, can be changed via SetMarkerImageCacheSize
@@ -175,31 +176,3 @@ func (c *CacheIndex) RemoveMarker(path string) {
 	delete(c.markers, path)
 }
 
-// HasTile checks if a tile is in the cache index
-func (c *CacheIndex) HasTile(path string) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	_, ok := c.tiles[path]
-	return ok
-}
-
-// AddTile adds a tile to the cache index
-func (c *CacheIndex) AddTile(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.tiles[path] = struct{}{}
-}
-
-// RemoveTile removes a tile from the cache index
-func (c *CacheIndex) RemoveTile(path string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.tiles, path)
-}
-
-// Stats returns cache index statistics
-func (c *CacheIndex) Stats() (staticMaps, multiStaticMaps, markers, tiles int) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.staticMaps), len(c.multiStaticMaps), len(c.markers), len(c.tiles)
-}

--- a/rampardos/internal/services/expiry_queue.go
+++ b/rampardos/internal/services/expiry_queue.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"container/heap"
 	"context"
 	"log/slog"
 	"os"
@@ -8,21 +9,36 @@ import (
 	"time"
 )
 
+// OwnedThreshold is the TTL at or above which a path is considered
+// "owned by CacheCleaner" — too long to track in the expiry queue.
+// An Add at this TTL drops any existing short-TTL entry and marks
+// the path as owned, blocking future short-TTL inserts until
+// CacheCleaner age-evicts the file and calls Unown.
+const OwnedThreshold = 24 * time.Hour
+
 // ExpiryQueue tracks files that should be deleted after a TTL.
-// A single background goroutine sweeps the queue periodically,
-// removing expired files and their cache index entries. Much more
-// efficient than spawning a goroutine per request.
+//
+// Internally it uses a min-heap ordered by expiresAt (so sweep
+// pops only expired entries without scanning the full set) plus a
+// map keyed by path for O(1) lookup on Add/extend.
+//
+// Add is extend-only: a shorter TTL never shortens an existing
+// entry. A TTL >= OwnedThreshold drops the entry entirely and
+// marks the path as owned by CacheCleaner.
 type ExpiryQueue struct {
-	mu      sync.Mutex
-	entries []expiryEntry
-	ctx     context.Context
-	cancel  context.CancelFunc
+	mu    sync.Mutex
+	h     expiryHeap
+	byKey map[string]*expiryItem
+	owned map[string]struct{}
+
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
-type expiryEntry struct {
-	paths     []string  // files to delete (path + basePath)
+type expiryItem struct {
+	path      string
 	expiresAt time.Time
-	onExpiry  func()    // optional callback (e.g. remove from cache index)
+	index     int // managed by container/heap
 }
 
 // GlobalExpiryQueue is the shared instance.
@@ -31,22 +47,72 @@ var GlobalExpiryQueue *ExpiryQueue
 // InitExpiryQueue creates the global queue and starts the sweeper.
 func InitExpiryQueue(sweepInterval time.Duration) {
 	ctx, cancel := context.WithCancel(context.Background())
-	q := &ExpiryQueue{ctx: ctx, cancel: cancel}
+	q := &ExpiryQueue{
+		byKey: make(map[string]*expiryItem),
+		owned: make(map[string]struct{}),
+		ctx:   ctx,
+		cancel: cancel,
+	}
+	heap.Init(&q.h)
 	GlobalExpiryQueue = q
 	go q.sweepLoop(sweepInterval)
 }
 
-// Add queues one or more file paths for deletion after ttl.
-// The optional onExpiry callback runs after files are deleted
-// (e.g. to remove cache index entries).
+// Add schedules one or more paths for deletion after ttl. Semantics:
+//
+//   - If ttl >= OwnedThreshold, any existing short-TTL entry for the
+//     path is dropped and the path is marked "owned by CacheCleaner."
+//     Future short-TTL Adds for the same path are no-ops until Unown.
+//   - Otherwise, extend-only: if the path already has an entry whose
+//     expiresAt is later than now+ttl, the call is a no-op. A shorter
+//     TTL never shortens an existing scheduled deletion.
+//   - If the path is in the owned set, the call is a no-op regardless
+//     of TTL (CacheCleaner owns its lifecycle).
+//
+// The onExpiry parameter is accepted for API compatibility but unused
+// in the current codebase (all callers pass nil). It is stored on the
+// item and called after the file is deleted, if non-nil.
 func (q *ExpiryQueue) Add(ttl time.Duration, onExpiry func(), paths ...string) {
 	q.mu.Lock()
-	q.entries = append(q.entries, expiryEntry{
-		paths:     paths,
-		expiresAt: time.Now().Add(ttl),
-		onExpiry:  onExpiry,
-	})
-	q.mu.Unlock()
+	defer q.mu.Unlock()
+
+	now := time.Now()
+	for _, p := range paths {
+		if ttl >= OwnedThreshold {
+			if item, ok := q.byKey[p]; ok {
+				heap.Remove(&q.h, item.index)
+				delete(q.byKey, p)
+			}
+			q.owned[p] = struct{}{}
+			continue
+		}
+		if _, ok := q.owned[p]; ok {
+			continue
+		}
+		newExp := now.Add(ttl)
+		if item, ok := q.byKey[p]; ok {
+			if !newExp.After(item.expiresAt) {
+				continue
+			}
+			item.expiresAt = newExp
+			heap.Fix(&q.h, item.index)
+			continue
+		}
+		item := &expiryItem{path: p, expiresAt: newExp}
+		heap.Push(&q.h, item)
+		q.byKey[p] = item
+	}
+}
+
+// Unown removes paths from the owned set. Called by CacheCleaner
+// when a file is age-evicted so a future request can re-enter the
+// expiry-queue lifecycle.
+func (q *ExpiryQueue) Unown(paths ...string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for _, p := range paths {
+		delete(q.owned, p)
+	}
 }
 
 // Stop cancels the background sweeper.
@@ -71,18 +137,12 @@ func (q *ExpiryQueue) sweep() {
 	now := time.Now()
 
 	q.mu.Lock()
-	// Filter in-place to avoid allocating a new slice every sweep.
-	n := 0
-	var expired []expiryEntry
-	for _, e := range q.entries {
-		if now.After(e.expiresAt) {
-			expired = append(expired, e)
-		} else {
-			q.entries[n] = e
-			n++
-		}
+	var expired []*expiryItem
+	for q.h.Len() > 0 && !q.h[0].expiresAt.After(now) {
+		item := heap.Pop(&q.h).(*expiryItem)
+		delete(q.byKey, item.path)
+		expired = append(expired, item)
 	}
-	q.entries = q.entries[:n]
 	q.mu.Unlock()
 
 	if len(expired) == 0 {
@@ -90,19 +150,43 @@ func (q *ExpiryQueue) sweep() {
 	}
 
 	count := 0
-	for _, e := range expired {
-		for _, path := range e.paths {
-			if err := os.Remove(path); err == nil {
-				count++
-			} else if !os.IsNotExist(err) {
-				slog.Debug("Expiry queue: failed to remove file", "path", path, "error", err)
-			}
-		}
-		if e.onExpiry != nil {
-			e.onExpiry()
+	for _, item := range expired {
+		if err := os.Remove(item.path); err == nil {
+			count++
+		} else if !os.IsNotExist(err) {
+			slog.Debug("Expiry queue: failed to remove file", "path", item.path, "error", err)
 		}
 	}
 	if count > 0 {
 		slog.Info("Expiry queue swept", "deleted", count)
 	}
+}
+
+// --- min-heap implementation for container/heap ---
+
+type expiryHeap []*expiryItem
+
+func (h expiryHeap) Len() int           { return len(h) }
+func (h expiryHeap) Less(i, j int) bool { return h[i].expiresAt.Before(h[j].expiresAt) }
+
+func (h expiryHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+func (h *expiryHeap) Push(x any) {
+	item := x.(*expiryItem)
+	item.index = len(*h)
+	*h = append(*h, item)
+}
+
+func (h *expiryHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*h = old[:n-1]
+	return item
 }

--- a/rampardos/internal/services/expiry_queue.go
+++ b/rampardos/internal/services/expiry_queue.go
@@ -14,6 +14,11 @@ import (
 // An Add at this TTL drops any existing short-TTL entry and marks
 // the path as owned, blocking future short-TTL inserts until
 // CacheCleaner age-evicts the file and calls Unown.
+//
+// Callers must only use OwnedThreshold for paths in folders that
+// have a CacheCleaner configured (maxAge + clearDelay set). If the
+// cleaner is absent, Unown is never called and the owned set grows
+// for the process lifetime.
 const OwnedThreshold = 24 * time.Hour
 
 // ExpiryQueue tracks files that should be deleted after a TTL.
@@ -68,11 +73,7 @@ func InitExpiryQueue(sweepInterval time.Duration) {
 //     TTL never shortens an existing scheduled deletion.
 //   - If the path is in the owned set, the call is a no-op regardless
 //     of TTL (CacheCleaner owns its lifecycle).
-//
-// The onExpiry parameter is accepted for API compatibility but unused
-// in the current codebase (all callers pass nil). It is stored on the
-// item and called after the file is deleted, if non-nil.
-func (q *ExpiryQueue) Add(ttl time.Duration, onExpiry func(), paths ...string) {
+func (q *ExpiryQueue) Add(ttl time.Duration, paths ...string) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 

--- a/rampardos/internal/services/renderer/integration_test.go
+++ b/rampardos/internal/services/renderer/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -63,7 +64,7 @@ func TestIntegrationRealWorker(t *testing.T) {
 
 	// Build a SpawnFactory that launches the real Node worker with the
 	// CLI args render-worker.js expects.
-	sf := func(styleID, preparedStylePath string) func() (*worker, error) {
+	sf := func(styleID, preparedStylePath string, ratio int) func() (*worker, error) {
 		return func() (*worker, error) {
 			return spawnWorker(workerArgs{
 				binary:  cfg.NodeBinary,
@@ -75,6 +76,7 @@ func TestIntegrationRealWorker(t *testing.T) {
 					"--mbtiles", cfg.MbtilesFile,
 					"--styles-dir", cfg.StylesDir,
 					"--fonts-dir", cfg.FontsDir,
+					"--ratio", strconv.Itoa(ratio),
 				},
 				handshakeTimeout: cfg.StartupTimeout,
 			})

--- a/rampardos/internal/services/renderer/nodepool.go
+++ b/rampardos/internal/services/renderer/nodepool.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,18 +21,39 @@ import (
 	"github.com/lenisko/rampardos/internal/models"
 )
 
+// poolKey builds the map key for a (style, scale) pool. Scale=1 pools
+// use the bare styleID for backward compatibility with log messages
+// and the canary render path.
+func poolKey(styleID string, scale uint8) string {
+	if scale <= 1 {
+		return styleID
+	}
+	return styleID + "@" + strconv.FormatUint(uint64(scale), 10)
+}
+
+func parsePoolKey(key string) (styleID string, ratio int) {
+	if i := strings.LastIndex(key, "@"); i >= 0 {
+		if r, err := strconv.Atoi(key[i+1:]); err == nil {
+			return key[:i], r
+		}
+	}
+	return key, 1
+}
+
 // Ensure NodePoolRenderer satisfies the Renderer interface.
 var _ Renderer = (*NodePoolRenderer)(nil)
 
-// SpawnFactory builds a spawn closure for a given style. Production
-// callers pass a factory that constructs `node render-worker.js ...`
-// invocations; tests inject fake-worker spawners.
-type SpawnFactory func(styleID, preparedStylePath string) func() (*worker, error)
+// SpawnFactory builds a spawn closure for a given style and pixel
+// ratio. The ratio maps to maplibre-native's DPR: ratio=1 is standard,
+// ratio=2 is retina (same geographic extent, 2× pixel density).
+// Production callers pass a factory that constructs
+// `node render-worker.js ...` invocations; tests inject fake spawners.
+type SpawnFactory func(styleID, preparedStylePath string, ratio int) func() (*worker, error)
 
 // DefaultSpawnFactory returns a SpawnFactory that launches real Node
 // render-worker processes using the paths from cfg.
 func DefaultSpawnFactory(cfg Config) SpawnFactory {
-	return func(styleID, preparedStylePath string) func() (*worker, error) {
+	return func(styleID, preparedStylePath string, ratio int) func() (*worker, error) {
 		return func() (*worker, error) {
 			return spawnWorker(workerArgs{
 				binary:  cfg.NodeBinary,
@@ -42,6 +65,7 @@ func DefaultSpawnFactory(cfg Config) SpawnFactory {
 					"--mbtiles", cfg.MbtilesFile,
 					"--styles-dir", cfg.StylesDir,
 					"--fonts-dir", cfg.FontsDir,
+					"--ratio", strconv.Itoa(ratio),
 				},
 				handshakeTimeout: cfg.StartupTimeout,
 			})
@@ -94,7 +118,7 @@ func NewNodePoolRenderer(cfg Config, sf SpawnFactory) (*NodePoolRenderer, error)
 // loadPool reads the on-disk style.json, rewrites it via PrepareStyle,
 // writes the prepared version next to the original, and creates a
 // stylePool with the given spawn closure.
-func (npr *NodePoolRenderer) loadPool(id string) (*stylePool, error) {
+func (npr *NodePoolRenderer) loadPool(id string, ratio int) (*stylePool, error) {
 	styleFile := filepath.Join(npr.cfg.StylesDir, id, "style.json")
 	raw, err := os.ReadFile(styleFile)
 	if err != nil {
@@ -111,7 +135,7 @@ func (npr *NodePoolRenderer) loadPool(id string) (*stylePool, error) {
 		return nil, fmt.Errorf("write prepared style: %w", err)
 	}
 
-	spawn := npr.spawnFactory(id, preparedPath)
+	spawn := npr.spawnFactory(id, preparedPath, ratio)
 
 	return newStylePool(stylePoolConfig{
 		styleID:          id,
@@ -137,11 +161,20 @@ func (npr *NodePoolRenderer) RenderViewport(ctx context.Context, req ViewportReq
 }
 
 func (npr *NodePoolRenderer) renderViewportInternal(ctx context.Context, req ViewportRequest) ([]byte, error) {
-	pool, err := npr.getOrCreatePool(req.StyleID)
+	scale := int(req.Scale)
+	if scale < 1 {
+		scale = 1
+	}
+
+	pool, err := npr.getOrCreatePool(req.StyleID, req.Scale)
 	if err != nil {
 		return nil, err
 	}
 
+	// Send LOGICAL dimensions to the worker. The worker's map was
+	// constructed with ratio=scale, so it produces width*ratio ×
+	// height*ratio actual pixels covering the same geographic extent
+	// as a ratio=1 render at these logical dimensions.
 	frame := requestFrameForViewport(req)
 
 	rgba, err := pool.dispatch(ctx, frame)
@@ -149,22 +182,23 @@ func (npr *NodePoolRenderer) renderViewportInternal(ctx context.Context, req Vie
 		return nil, err
 	}
 
-	// The wire frame sends Width*Scale and Height*Scale as the actual
-	// pixel dimensions. encodeRGBA needs the actual size to match the buffer.
-	scale := int(req.Scale)
-	if scale < 1 {
-		scale = 1
-	}
+	// The RGBA buffer from the worker is width*scale × height*scale
+	// actual pixels (due to the map's ratio). encodeRGBA must match.
 	return encodeRGBA(rgba, req.Width*scale, req.Height*scale, req.Format)
 }
 
 // getOrCreatePool returns the pool for a style, creating it on first
 // use. Uses double-checked locking: fast RLock path for the common
 // case (pool already exists), slow Lock path for first-time creation.
-func (npr *NodePoolRenderer) getOrCreatePool(styleID string) (*stylePool, error) {
+func (npr *NodePoolRenderer) getOrCreatePool(styleID string, scale uint8) (*stylePool, error) {
+	if scale < 1 {
+		scale = 1
+	}
+	key := poolKey(styleID, scale)
+
 	// Fast path: pool already running.
 	npr.mu.RLock()
-	pool, ok := npr.pools[styleID]
+	pool, ok := npr.pools[key]
 	npr.mu.RUnlock()
 	if ok {
 		return pool, nil
@@ -174,23 +208,22 @@ func (npr *NodePoolRenderer) getOrCreatePool(styleID string) (*stylePool, error)
 	npr.mu.Lock()
 	defer npr.mu.Unlock()
 
-	// Double-check after acquiring write lock.
-	if pool, ok := npr.pools[styleID]; ok {
+	if pool, ok := npr.pools[key]; ok {
 		return pool, nil
 	}
 
-	// Verify the style exists on disk before spawning workers.
 	stylePath := filepath.Join(npr.cfg.StylesDir, styleID, "style.json")
 	if _, err := os.Stat(stylePath); err != nil {
 		return nil, fmt.Errorf("renderer: unknown style %q (no style.json at %s)", styleID, stylePath)
 	}
 
-	slog.Info("Creating renderer pool on first use", "style", styleID, "poolSize", npr.cfg.PoolSize)
-	pool, err := npr.loadPool(styleID)
+	ratio := int(scale)
+	slog.Info("Creating renderer pool on first use", "style", styleID, "ratio", ratio, "poolSize", npr.cfg.PoolSize)
+	pool, err := npr.loadPool(styleID, ratio)
 	if err != nil {
-		return nil, fmt.Errorf("renderer: create pool %q: %w", styleID, err)
+		return nil, fmt.Errorf("renderer: create pool %q ratio=%d: %w", styleID, ratio, err)
 	}
-	npr.pools[styleID] = pool
+	npr.pools[key] = pool
 	return pool, nil
 }
 
@@ -198,33 +231,33 @@ func (npr *NodePoolRenderer) getOrCreatePool(styleID string) (*stylePool, error)
 // disk. In-flight renders against old pools finish normally; new
 // renders block until the rebuild completes.
 func (npr *NodePoolRenderer) ReloadStyles(ctx context.Context) error {
-	// Snapshot active style IDs under a short read lock.
+	// Snapshot active pool keys under a short read lock.
 	npr.mu.RLock()
-	activeIDs := make([]string, 0, len(npr.pools))
-	for id := range npr.pools {
-		activeIDs = append(activeIDs, id)
+	activeKeys := make([]string, 0, len(npr.pools))
+	for key := range npr.pools {
+		activeKeys = append(activeKeys, key)
 	}
 	npr.mu.RUnlock()
 
 	// Build new pools OUTSIDE the lock so in-flight renders continue
 	// against the old pools without blocking. Each loadPool spawns
 	// workers and waits for handshakes — this can take seconds.
-	newPools := make(map[string]*stylePool, len(activeIDs))
-	for _, id := range activeIDs {
+	newPools := make(map[string]*stylePool, len(activeKeys))
+	for _, key := range activeKeys {
 		if ctx.Err() != nil {
-			// Context expired (e.g. SIGHUP timeout) — stop spawning.
 			for _, p := range newPools {
 				p.close()
 			}
 			return ctx.Err()
 		}
-		pool, err := npr.loadPool(id)
+		styleID, ratio := parsePoolKey(key)
+		pool, err := npr.loadPool(styleID, ratio)
 		if err != nil {
 			slog.Error("Failed to reload pool, style will be recreated on next request",
-				"style", id, "error", err)
+				"style", styleID, "ratio", ratio, "error", err)
 			continue
 		}
-		newPools[id] = pool
+		newPools[key] = pool
 	}
 
 	// Swap under a short write lock: replace pools map, then close
@@ -253,20 +286,16 @@ func (npr *NodePoolRenderer) Close() error {
 }
 
 // requestFrameForViewport builds the JSON wire frame sent to the
-// worker for a viewport render. Width and height are multiplied by
-// Scale to get the actual rendered pixel dimensions — the worker's
-// mbgl.Map is constructed with ratio:1, so DPR must be baked into
-// the dimensions rather than passed as a separate ratio field.
+// worker for a viewport render. Width and height are LOGICAL
+// dimensions — the worker's mbgl.Map is constructed with
+// ratio=scale, so it produces width*ratio × height*ratio actual
+// pixels covering the same geographic extent as these logical dims.
 func requestFrameForViewport(vp ViewportRequest) []byte {
-	scale := int(vp.Scale)
-	if scale < 1 {
-		scale = 1
-	}
 	m := map[string]any{
 		"zoom":    vp.Zoom,
 		"center":  []float64{vp.Longitude, vp.Latitude},
-		"width":   vp.Width * scale,
-		"height":  vp.Height * scale,
+		"width":   vp.Width,
+		"height":  vp.Height,
 		"bearing": vp.Bearing,
 		"pitch":   vp.Pitch,
 	}

--- a/rampardos/internal/services/renderer/nodepool_test.go
+++ b/rampardos/internal/services/renderer/nodepool_test.go
@@ -45,7 +45,7 @@ func TestNodePoolRendererRenderReturnsBytes(t *testing.T) {
 		RenderTimeout:  5 * time.Second,
 		StartupTimeout: 2 * time.Second,
 		DiscoverStyles: func() ([]string, error) { return []string{"basic"}, nil },
-	}, func(styleID, preparedPath string) func() (*worker, error) {
+	}, func(styleID, preparedPath string, ratio int) func() (*worker, error) {
 		return func() (*worker, error) {
 			return spawnWorker(workerArgs{
 				binary:           "bash",
@@ -91,7 +91,7 @@ func TestNodePoolRendererUnknownStyle(t *testing.T) {
 		RenderTimeout:  5 * time.Second,
 		StartupTimeout: 2 * time.Second,
 		DiscoverStyles: func() ([]string, error) { return []string{"basic"}, nil },
-	}, func(styleID, preparedPath string) func() (*worker, error) {
+	}, func(styleID, preparedPath string, ratio int) func() (*worker, error) {
 		return func() (*worker, error) {
 			return spawnWorker(workerArgs{
 				binary:           "bash",


### PR DESCRIPTION
## Summary

Originally scoped as a minimal basePath race fix, this PR grew to address three related areas that share the same cache/render pipeline:

### 1. basePath race fixes
- **Stale `HasStaticMap(basePath)` → 500**: cache index could lie about base file existence after TTL cleanup. Removed basePath from the cache index entirely; `os.Stat` is now authoritative.
- **Shared basePath in per-request TTL**: one caller's TTL could delete a base still used by siblings. basePath is now enqueued alongside path, with extend-only semantics so the longest TTL wins.
- **Per-basePath singleflight** (`baseSfg`): deduplicates concurrent sibling base renders (same viewport, different overlays).

### 2. Scale/ratio rendering fix
- **Wrong geographic extent at scale>1**: the previous implementation doubled viewport width at `ratio: 1`, which doubled the field of view instead of the pixel density. Each scale=2 tile covered 4× its intended geography.
- **Per-scale worker pools**: pool key is now `styleID@scale`. Workers at `ratio: 2` produce 1024×1024 tiles covering the correct one-tile geographic extent at 2× pixel density.
- **`hasScale` for local styles**: crop math now accounts for scaled tile dimensions.
- **render-worker.js**: accepts `--ratio` CLI arg, uses it in Map constructor.

### 3. Expiry queue rewrite
- **Extend-only semantics**: a shorter TTL never shortens an existing entry. Concurrent nocache (30s floor) + pregenerate+ttl=300 → the 300s entry wins. Fixes the race where nocache's `os.Remove` deleted a file that pregenerate had just handed to subscribers as a URL (404 storm on Discord/Telegram).
- **Owned-path set**: normal-cached files (no explicit TTL) are marked as "owned by CacheCleaner." Future short-TTL Adds are no-ops until CacheCleaner age-evicts and calls `Unown`.
- **Min-heap + map**: O(log N) insert/extend, O(1) path lookup, sweep stops at first non-expired entry. Replaces O(N) slice scan.
- **No more `os.Remove` in handler nocache paths**: all deletion goes through the queue.

### 4. Cache index cleanup
- Stripped `CacheIndex` to just the resized-marker LRU (the one cache that saves real work). Deleted file-presence maps for staticMap/multiStaticMap/marker/tile — each saved a sub-µs stat syscall while introducing latent-stale failure modes.
- Multi dispatcher short-circuits on `ctx.Done()` to stop doing useless work for disconnected clients.

## Files changed

```
+648 / -467 across 8 files (including ~180 lines of race tests)
```

## Test plan

- [x] `go test -race ./internal/handlers/ -count=20` — stable pass (including gate-deterministic singleflight test)
- [x] `go test ./...` — all packages green
- [x] Production verified: ratio=1 and ratio=2 pools start correctly, tiles align geographically, markers positioned correctly on both street and satellite panels
- [x] Purged stale 512×512 scale=2 tiles from pre-ratio-fix era; fresh 1024×1024 tiles render correctly
- [x] Concurrent pregenerate+ttl + nocache requests no longer 404 on the pregenerated URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)