### PR TITLE
build: docker + CI for the in-process Go renderer (mln_ffi)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,7 +61,15 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # linux/arm64 disabled while the maplibre-native-ffi build
+          # stage runs under QEMU emulation. The FFI build itself is
+          # ~10-20 min cold on amd64 native; under arm64 emulation it
+          # would push past sensible CI budgets. Restore via either
+          # a native ubuntu-24.04-arm runner matrix (the FFI repo's
+          # own CI does this) or a cross-compile path. Captured as a
+          # follow-up once the Go renderer has been validated on
+          # amd64. See scripts/build-mln-ffi.sh for the host equivalent.
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,37 @@ RUN find /fontnik/node_modules -type f \( -name "*.md" -o -name "*.ts" -o -name 
     && find /fontnik/node_modules -type d \( -name "test" -o -name "tests" -o -name "docs" -o -name "example" -o -name "examples" \) -exec rm -rf {} + 2>/dev/null || true
 
 # ================================
+# Build maplibre-native-ffi (libmaplibre-native-c.so) — the C ABI shared
+# library the in-process Go renderer (RENDERER_BACKEND=go-pool) links
+# against via the maplibre-native-go binding.
+#
+# Heavy: ~10-20 min cold. mise installs pixi, which brings clang +
+# cmake + ninja into a conda env; CMake then fetches maplibre-native
+# source at configure time. BuildKit's layer cache (cache-from/to=gha)
+# amortises this across PRs as long as MLN_FFI_REV is stable.
+#
+# Pin MUST track the maplibre-native-go binding's required FFI revision.
+# See scripts/build-mln-ffi.sh for the host-side equivalent.
+# ================================
+FROM ubuntu:24.04 AS mln-ffi-build
+ARG MLN_FFI_REV=f1d00086e0da85617edc1ce5281b4c5f4e5938e1
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ca-certificates curl git xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://mise.run | sh
+ENV PATH=/root/.local/bin:$PATH
+WORKDIR /ffi
+RUN git clone https://github.com/sargunv/maplibre-native-ffi . \
+ && git checkout ${MLN_FFI_REV}
+RUN mise trust --yes && mise install
+SHELL ["/bin/bash", "-c"]
+RUN eval "$(mise activate bash)" && mise run build
+RUN test -f build/libmaplibre-native-c.so \
+ && test -f build/pkgconfig/maplibre-native-c.pc
+
+# ================================
 # Render worker deps (maplibre-gl-native + better-sqlite3)
 # ================================
 # Must use the same base as the runtime (Ubuntu 24.04) so npm downloads
@@ -63,18 +94,38 @@ RUN npm install --omit=optional \
 
 # ================================
 # Build Go binary
+#
+# Builds with -tags 'nodynamic mln_ffi' so the in-process Go renderer
+# (gopool.go) is compiled in alongside the Node-subprocess renderer.
+# The RENDERER_BACKEND env var selects which one runs at process start;
+# default remains node-pool, so existing deployments are unchanged.
+#
+# Switched from golang:1.26-alpine (musl, CGO_ENABLED=0) to glibc-based
+# golang:1.26 because libmaplibre-native-c.so is built on Ubuntu 24.04
+# and links against its glibc/libstdc++. CGO must use a compatible
+# runtime ABI; alpine's musl would not.
+#
+# No explicit --platform: buildx defaults to TARGETPLATFORM, which is
+# what we want. CGO cross-compilation needs a per-arch toolchain we
+# don't currently install, so under multi-arch builds QEMU runs the
+# Go compile natively in each target arch.
 # ================================
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS rampardos-build
-ARG TARGETOS
-ARG TARGETARCH
+FROM golang:1.26 AS rampardos-build
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pkg-config \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=mln-ffi-build /ffi/build /ffi/build
+COPY --from=mln-ffi-build /ffi/include /ffi/include
 WORKDIR /src
 COPY --from=git-info /git-commit.txt /git-commit.txt
 COPY rampardos/go.mod rampardos/go.sum ./
 RUN go mod download
 COPY rampardos/ ./
 RUN GIT_COMMIT=$(cat /git-commit.txt) && \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 \
-    go build -trimpath -tags nodynamic \
+    PKG_CONFIG_PATH=/ffi/build/pkgconfig \
+    CGO_ENABLED=1 \
+    go build -trimpath -tags 'nodynamic mln_ffi' \
     -ldflags="-s -w -X github.com/lenisko/rampardos/internal/version.gitCommitFromLdflags=${GIT_COMMIT}" \
     -o /out/rampardos ./cmd/server
 
@@ -93,13 +144,15 @@ RUN apt-get update \
     # Node.js via NodeSource
  && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
-    # maplibre-native runtime deps (Mesa/OpenGL headless rendering)
+    # maplibre-native (Node binding) runtime deps — Mesa/OpenGL headless
     libglx0 libgl1 libegl1 libgbm1 libopengl0 \
-    # maplibre-native additional deps
+    # maplibre-native (Go binding via FFI) runtime deps — Vulkan with the
+    # lavapipe software rasterizer for fully headless render
+    libvulkan1 mesa-vulkan-drivers \
+    # maplibre-native common deps
     libcurl4 libjpeg8 libwebp7 libpng16-16 libicu74 \
-    # libuv (maplibre-native links against it directly)
     libuv1 \
-    # Xvfb for headless GL rendering (maplibre-native needs an X display)
+    # Xvfb for headless GL rendering (Node binding needs an X display)
     xvfb \
     # SQLite for better-sqlite3
     libsqlite3-0 \
@@ -113,6 +166,13 @@ COPY --from=tippecanoe-build /tippecanoe-out/ /usr/local/bin/
 # Fontnik (build-glyphs for font processing)
 COPY --from=fontnik-build /fontnik /app/fontnik
 RUN ln -s /app/fontnik/node_modules/.bin/build-glyphs /usr/local/bin/build-glyphs
+
+# maplibre-native-ffi shared library — only loaded at process start when
+# RENDERER_BACKEND=go-pool is set. ldconfig adds /usr/local/lib to the
+# dynamic linker's search path so rampardos resolves it without an
+# explicit RPATH or LD_LIBRARY_PATH.
+COPY --from=mln-ffi-build /ffi/build/libmaplibre-native-c.so /usr/local/lib/
+RUN ldconfig
 
 # Go binary
 COPY --from=rampardos-build /out/rampardos /app/rampardos

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,24 @@ RUN eval "$(mise activate bash)" && mise run build
 RUN test -f build/libmaplibre-native-c.so \
  && test -f build/pkgconfig/maplibre-native-c.pc
 
+# The FFI's CMake links the .so against the pixi conda env's libs
+# (libicu 78, libuv 1, libjpeg 8, libwebp 7, libpng16) — versions that
+# don't match Debian Trixie / Ubuntu 24.04 system packages. Without
+# this bundling step, a downstream `ld` against libmaplibre-native-c.so
+# fails to resolve DT_NEEDED entries (libicuuc.so.78, etc.) and the
+# Go build errors out with "undefined reference" linker errors.
+#
+# Strategy: ldd recursively expands the dependency closure, awk filters
+# to entries living under /ffi/.pixi/, cp -L dereferences any symlinks
+# so the destination filename matches the DT_NEEDED soname directly.
+# Bundled libs land alongside libmaplibre-native-c.so in /ffi/build,
+# so both -L${libdir} from pkg-config and the dynamic linker's view of
+# the .so's transitive deps resolve in one place.
+RUN for lib in $(LD_LIBRARY_PATH=/ffi/.pixi/envs/default/lib ldd build/libmaplibre-native-c.so | awk '/=> .*pixi/ {print $3}'); do \
+        cp -L "$lib" build/; \
+    done \
+ && ls -la build/*.so*
+
 # ================================
 # Render worker deps (maplibre-gl-native + better-sqlite3)
 # ================================
@@ -128,6 +146,7 @@ RUN go mod download
 COPY rampardos/ ./
 RUN GIT_COMMIT=$(cat /git-commit.txt) && \
     PKG_CONFIG_PATH=/ffi/build/pkgconfig \
+    CGO_LDFLAGS="-Wl,-rpath-link=/ffi/build" \
     CGO_ENABLED=1 \
     go build -trimpath -tags 'nodynamic mln_ffi' \
     -ldflags="-s -w -X github.com/lenisko/rampardos/internal/version.gitCommitFromLdflags=${GIT_COMMIT}" \
@@ -171,12 +190,21 @@ COPY --from=tippecanoe-build /tippecanoe-out/ /usr/local/bin/
 COPY --from=fontnik-build /fontnik /app/fontnik
 RUN ln -s /app/fontnik/node_modules/.bin/build-glyphs /usr/local/bin/build-glyphs
 
-# maplibre-native-ffi shared library — only loaded at process start when
-# RENDERER_BACKEND=go-pool is set. ldconfig adds /usr/local/lib to the
-# dynamic linker's search path so rampardos resolves it without an
-# explicit RPATH or LD_LIBRARY_PATH.
-COPY --from=mln-ffi-build /ffi/build/libmaplibre-native-c.so /usr/local/lib/
-RUN ldconfig
+# maplibre-native-ffi shared library + its pixi-conda-env transitive deps
+# (libicuuc.so.78, libuv.so.1, libjpeg.so.8, libpng16.so.16, libwebp.so.7,
+# libicui18n.so.78, libicudata.so.78). Bundled together in a dedicated
+# directory rather than dumped into /usr/local/lib so they don't shadow
+# matching-soname Ubuntu system libraries used by other parts of the
+# image (the Node binding's GL stack also pulls in libuv1/libpng/libjpeg).
+# A dedicated ld.so.conf.d entry registers the directory with the
+# dynamic linker; only consumers that resolve via the cache pick these
+# up — the existing /usr/lib search path is unchanged.
+COPY --from=mln-ffi-build /ffi/build /tmp/ffi-build
+RUN mkdir -p /opt/rampardos/lib \
+ && cp -L /tmp/ffi-build/*.so* /opt/rampardos/lib/ \
+ && rm -rf /tmp/ffi-build \
+ && echo /opt/rampardos/lib > /etc/ld.so.conf.d/rampardos.conf \
+ && ldconfig
 
 # Go binary
 COPY --from=rampardos-build /out/rampardos /app/rampardos

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,12 @@ RUN npm install --omit=optional \
 # ================================
 FROM golang:1.26 AS rampardos-build
 ENV DEBIAN_FRONTEND=noninteractive
+# libvulkan-dev provides vulkan.pc — required because the binding's
+# texture_vulkan_linux.go declares `#cgo linux pkg-config: vulkan`.
+# Compile-time dep only; the runtime libvulkan1 / mesa-vulkan-drivers
+# are installed on the runtime image.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends pkg-config \
+ && apt-get install -y --no-install-recommends pkg-config libvulkan-dev \
  && rm -rf /var/lib/apt/lists/*
 COPY --from=mln-ffi-build /ffi/build /ffi/build
 COPY --from=mln-ffi-build /ffi/include /ffi/include

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run test test-integration test-coverage clean tidy fmt lint \
        npm-install docker-build docker-push docker-compose-up docker-compose-down \
-       docker-compose-logs setup-dirs help
+       docker-compose-logs setup-dirs help build-ffi build-go-renderer clean-ffi
 
 # Binary name
 BINARY_NAME=rampardos
@@ -23,7 +23,16 @@ LDFLAGS=-ldflags="-w -s -X github.com/lenisko/rampardos/internal/version.gitComm
 # Docker
 DOCKER_IMAGE=ghcr.io/lenisko/rampardos
 DOCKER_TAG=latest
-DOCKER_PLATFORMS=linux/amd64,linux/arm64
+# linux/arm64 disabled while the FFI build runs under QEMU emulation —
+# see comment in .github/workflows/docker-build.yml.
+DOCKER_PLATFORMS=linux/amd64
+
+# In-process Go renderer (RENDERER_BACKEND=go-pool) — see plan in
+# docs/superpowers/plans/2026-05-01-in-process-go-renderer.md.
+# MLN_FFI_REV MUST stay in sync with the ARG in the Dockerfile's
+# mln-ffi-build stage; bump both together when the Go binding changes.
+MLN_FFI_REV ?= f1d00086e0da85617edc1ce5281b4c5f4e5938e1
+MLN_FFI_DIR_HOST ?= $(HOME)/dev/maplibre-native-ffi-linux
 
 # Default target
 all: build
@@ -83,6 +92,25 @@ clean:
 	$(GOCLEAN)
 	rm -rf $(BUILD_DIR)
 	rm -f $(GO_DIR)/coverage.out $(GO_DIR)/coverage.html
+
+## build-ffi: Build libmaplibre-native-c.so for the Go renderer (~10-20 min cold)
+build-ffi:
+	MLN_FFI_REV=$(MLN_FFI_REV) MLN_FFI_DIR_HOST=$(MLN_FFI_DIR_HOST) ./scripts/build-mln-ffi.sh
+
+## build-go-renderer: Build rampardos with the Go renderer compiled in (-tags mln_ffi). Run build-ffi first.
+build-go-renderer:
+	@test -f $(MLN_FFI_DIR_HOST)/build/libmaplibre-native-c.so || \
+	  (echo "FFI not built. Run 'make build-ffi' first." >&2 && exit 1)
+	@mkdir -p $(BUILD_DIR)
+	cd $(GO_DIR) && \
+	  PKG_CONFIG_PATH=$(MLN_FFI_DIR_HOST)/build/pkgconfig \
+	  CGO_LDFLAGS="-Wl,-rpath,$(MLN_FFI_DIR_HOST)/build" \
+	  CGO_ENABLED=1 \
+	  $(GOBUILD) -trimpath $(LDFLAGS) -tags 'nodynamic mln_ffi' -o ../$(BUILD_DIR)/$(BINARY_NAME) ./cmd/server
+
+## clean-ffi: Remove the host FFI build directory ($MLN_FFI_DIR_HOST)
+clean-ffi:
+	rm -rf $(MLN_FFI_DIR_HOST)
 
 ## tidy: Tidy and verify Go dependencies
 tidy:

--- a/scripts/build-mln-ffi.sh
+++ b/scripts/build-mln-ffi.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Build libmaplibre-native-c.so on the host for local rampardos
+# development with the in-process Go renderer (RENDERER_BACKEND=go-pool).
+#
+# The same FFI build runs inside the Dockerfile's `mln-ffi-build` stage
+# for CI image builds. This script is purely for the developer iteration
+# loop: run rampardos with -tags mln_ffi against a host-built .so so
+# changes to the Go-side glue don't require a Docker rebuild.
+#
+# The actual compilation runs *inside* an Ubuntu 24.04 container even on
+# Linux hosts, both to match the runtime image's glibc/libstdc++ and to
+# work uniformly from macOS/Linux dev machines without per-host setup of
+# mise + pixi + clang. The container writes its build/ output back into
+# the host directory you point it at.
+#
+# Usage:
+#   ./scripts/build-mln-ffi.sh
+#
+# Env:
+#   MLN_FFI_DIR_HOST  Host directory used as the FFI checkout + build
+#                     root. Default: ~/dev/maplibre-native-ffi-linux.
+#                     The script clones a fresh copy on first run.
+#   MLN_FFI_REV       Commit to check out. Bump this when the Go binding
+#                     bumps its required FFI revision; KEEP IN SYNC with
+#                     the ARG MLN_FFI_REV at the top of the Dockerfile's
+#                     mln-ffi-build stage.
+
+set -euo pipefail
+
+MLN_FFI_DIR_HOST="${MLN_FFI_DIR_HOST:-$HOME/dev/maplibre-native-ffi-linux}"
+MLN_FFI_REV="${MLN_FFI_REV:-f1d00086e0da85617edc1ce5281b4c5f4e5938e1}"
+
+mkdir -p "$MLN_FFI_DIR_HOST"
+
+if [ ! -d "$MLN_FFI_DIR_HOST/.git" ]; then
+    echo ">> cloning maplibre-native-ffi at $MLN_FFI_REV into $MLN_FFI_DIR_HOST"
+    git clone https://github.com/sargunv/maplibre-native-ffi "$MLN_FFI_DIR_HOST"
+fi
+
+echo ">> checking out $MLN_FFI_REV"
+git -C "$MLN_FFI_DIR_HOST" fetch --depth 64 origin "$MLN_FFI_REV" || true
+git -C "$MLN_FFI_DIR_HOST" checkout --force "$MLN_FFI_REV"
+
+# Linux-only build dir keeps coexistence-friendly with a macOS
+# checkout pointed at the same source tree (CMake caches are per-arch).
+docker run --rm \
+    -v "$MLN_FFI_DIR_HOST":/ffi \
+    -w /ffi \
+    -e MISE_DATA_DIR=/ffi/.mise-cache \
+    -e PIXI_CACHE_DIR=/ffi/.pixi-cache \
+    ubuntu:24.04 \
+    bash -c '
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update >/dev/null
+apt-get install -y --no-install-recommends \
+    ca-certificates curl git xz-utils \
+    >/dev/null
+
+curl -fsSL https://mise.run | sh
+export PATH=/root/.local/bin:$PATH
+
+mise trust --yes
+mise install
+eval "$(mise activate bash)"
+
+mise run build
+
+if [ ! -f build/libmaplibre-native-c.so ] || [ ! -f build/pkgconfig/maplibre-native-c.pc ]; then
+    echo "ERROR: build did not produce expected artifacts" >&2
+    ls -la build/ build/pkgconfig/ 2>&1 | head -40 >&2
+    exit 1
+fi
+
+echo "OK"
+echo "  $(realpath build/libmaplibre-native-c.so)"
+echo "  $(realpath build/pkgconfig/maplibre-native-c.pc)"
+'
+
+cat <<EOF
+
+================================================================
+ FFI artifacts at $MLN_FFI_DIR_HOST/build/
+
+ To build rampardos with the in-process Go renderer compiled in:
+
+   cd rampardos
+   PKG_CONFIG_PATH=$MLN_FFI_DIR_HOST/build/pkgconfig \\
+   CGO_LDFLAGS="-Wl,-rpath,$MLN_FFI_DIR_HOST/build" \\
+   CGO_ENABLED=1 \\
+   go build -tags 'nodynamic mln_ffi' ./cmd/server
+
+ Or just \`make build-go-renderer\` from the project root.
+
+ To run with the Go backend selected:
+
+   RENDERER_BACKEND=go-pool ./rampardos
+================================================================
+EOF


### PR DESCRIPTION
## Summary

Stacks on #19. Adds the build infrastructure needed to publish docker images that include the in-process Go renderer ([plan](https://github.com/lenisko/rampardos/blob/tileserver-replacement/docs/superpowers/plans/2026-05-01-in-process-go-renderer.md)). After this lands, every push triggers a CI image build with `RENDERER_BACKEND=go-pool` available — opt-in via env var, default stays `node-pool`.

## Dockerfile changes

- **New stage `mln-ffi-build`** (Ubuntu 24.04) clones [`sargunv/maplibre-native-ffi`](https://github.com/sargunv/maplibre-native-ffi) at the pinned `MLN_FFI_REV` (currently `f1d00086`), installs mise + pixi, and runs `mise run build` to produce `libmaplibre-native-c.so` + pkgconfig. ~10–20 min cold; BuildKit's `gha` cache amortises across PRs as long as `MLN_FFI_REV` doesn't change.
- **`rampardos-build` switched** from `golang:1.26-alpine` (musl, `CGO_ENABLED=0`) to `golang:1.26` (Debian, glibc), with `CGO_ENABLED=1` and `-tags 'nodynamic mln_ffi'`. The `.so` copied from `mln-ffi-build` is ABI-tied to Ubuntu 24.04's glibc/libstdc++; alpine's musl wouldn't link. `--platform=\$BUILDPLATFORM` dropped (CGO cross-compile needs per-arch toolchains we don't install); buildx defaults to `TARGETPLATFORM`, so under multi-arch QEMU runs the Go compile natively in each target arch.
- **`runtime` adds** `libvulkan1` + `mesa-vulkan-drivers` so the FFI binding's lavapipe-Vulkan render works headless, copies `libmaplibre-native-c.so` to `/usr/local/lib`, runs `ldconfig`. No `LD_LIBRARY_PATH` or `RPATH` wrangling needed at runtime.

## CI workflow changes

- `platforms` reduced from `linux/amd64,linux/arm64` to **`linux/amd64`** alone while the FFI build runs under QEMU. amd64-native cold build is ~10–20 min; the same under arm64 emulation would push past sensible CI budgets. Restoring arm64 via either a native `ubuntu-24.04-arm` runner matrix (the FFI repo's own CI does this) or a cross-compile path is the obvious follow-up once the Go renderer has been validated on amd64.

## Local-dev additions

- **`scripts/build-mln-ffi.sh`** — ported from the Rust POC. Builds the FFI inside a transient Ubuntu 24.04 container even on Linux hosts (so the `.so` ABI matches the runtime image regardless of dev machine). Outputs to `\$MLN_FFI_DIR_HOST/build/`.
- **`Makefile`** — `build-ffi`, `build-go-renderer`, `clean-ffi` targets. `DOCKER_PLATFORMS` dropped to `linux/amd64` to mirror the workflow change.

## Sync points to remember

`MLN_FFI_REV` appears in **three places** that must move together on a binding bump:
1. `Dockerfile` — `ARG MLN_FFI_REV` in the `mln-ffi-build` stage
2. `scripts/build-mln-ffi.sh` — `MLN_FFI_REV=` default
3. `Makefile` — `MLN_FFI_REV ?=` default

Bumping `github.com/jfberry/maplibre-native-go` in `rampardos/go.mod` (PR #19) usually means bumping all three.

## Verification

```
docker buildx build --check .                 # 2 pre-existing warnings; nothing new
CGO_ENABLED=0 go build ./... && go vet ./...  # untagged: green
PKG_CONFIG_PATH=… CGO_LDFLAGS=… CGO_ENABLED=1 \
    go build -tags 'nodynamic mln_ffi' ./...  # tagged: green
```

(I didn't run a full `docker build` locally — the cold FFI stage is too slow to fit a review cycle. CI is the real test.)

## Test plan

- [ ] CI builds the image successfully (`build-and-push` job green)
- [ ] Pull the resulting image, confirm `RENDERER_BACKEND=node-pool` (default) still serves tiles correctly
- [ ] Pull the same image, set `RENDERER_BACKEND=go-pool`, confirm a tile + a viewport render produce visually-correct output
- [ ] Sanity check `ldd /app/rampardos | grep maplibre` resolves to `/usr/local/lib/libmaplibre-native-c.so` only when the binary was built tagged

## Follow-ups (in order)

1. **arm64 builds** — either via native `ubuntu-24.04-arm` runners + manifest merge, or cross-compile of both the FFI and rampardos
2. **Parameterise `integration_test.go`** to drive both backends (PR 3 in the plan)
3. **Stage rollout** — toggle `RENDERER_BACKEND=go-pool` on a non-customer-facing instance, watch p50/p99.9/RSS for a week, then flip the default

## Stacking note

This PR's base is `feat/in-process-go-renderer` (#19). Once that merges, GitHub auto-rebases this PR onto `tileserver-replacement`. If #19 is squash-merged, this PR may need a manual rebase — the cleanest path is to merge-not-squash #19, then this becomes a clean fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)