### PR TITLE
fix: support MapTiler-exported style imports end-to-end

### DIFF
--- a/rampardos-render-worker/render-worker.js
+++ b/rampardos-render-worker/render-worker.js
@@ -33,6 +33,8 @@
  */
 
 const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
 const zlib = require("zlib");
 const Database = require("better-sqlite3");
 const mbgl = require("@maplibre/maplibre-gl-native");
@@ -113,6 +115,72 @@ function readTile(z, x, y) {
   return data;
 }
 
+// Remote sprite/glyph resources (e.g. raw.githubusercontent.com-hosted
+// sprite sheets) are fetched once per worker process on first request,
+// then cached on disk in <styleDir>/.remote/ so subsequent worker
+// startups, recycles, and process restarts replay from local files.
+// The cache is scoped to the style: removing the style directory also
+// removes its remote cache.
+const remoteCacheDir = path.join(path.dirname(args["style-path"]), ".remote");
+const remoteFetchMaxBytes = 50 * 1024 * 1024; // 50 MB
+const remoteFetchTimeoutMs = 30 * 1000;
+
+function remoteCachePath(url) {
+	const hash = crypto.createHash("sha256").update(url).digest("hex");
+	let ext = "";
+	try {
+		ext = path.extname(new URL(url).pathname);
+	} catch (_) {
+		// Malformed URL — no extension. The fetch below will reject it
+		// before we get here, but be defensive.
+	}
+	return path.join(remoteCacheDir, hash + ext);
+}
+
+async function fetchRemoteResource(url) {
+	const cachePath = remoteCachePath(url);
+	try {
+		return fs.readFileSync(cachePath);
+	} catch (_) {
+		// Cache miss; fall through to network fetch.
+	}
+
+	const ctrl = new AbortController();
+	const timer = setTimeout(() => ctrl.abort(), remoteFetchTimeoutMs);
+	let res;
+	try {
+		res = await fetch(url, { signal: ctrl.signal });
+	} finally {
+		clearTimeout(timer);
+	}
+	if (!res.ok) {
+		throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+	}
+	const cl = res.headers.get("content-length");
+	if (cl && Number(cl) > remoteFetchMaxBytes) {
+		throw new Error(`remote resource too large (${cl} bytes) for ${url}`);
+	}
+	const ab = await res.arrayBuffer();
+	if (ab.byteLength > remoteFetchMaxBytes) {
+		throw new Error(`remote resource too large (${ab.byteLength} bytes) for ${url}`);
+	}
+	const buf = Buffer.from(ab);
+
+	// Persist to the per-style cache. Concurrent workers may race here;
+	// the rename is atomic on POSIX so the last writer wins cleanly.
+	// Cache write failures are non-fatal — the render still succeeds
+	// using the in-memory buffer we already have.
+	try {
+		fs.mkdirSync(remoteCacheDir, { recursive: true });
+		const tmp = cachePath + ".tmp." + process.pid + "." + Date.now();
+		fs.writeFileSync(tmp, buf);
+		fs.renameSync(tmp, cachePath);
+	} catch (_) {
+		// Best-effort cache; the render itself doesn't depend on it.
+	}
+	return buf;
+}
+
 // parseMbtilesTileURL assumes the URL prefix matches byte-for-byte
 // what rampardos/internal/services/renderer/styleprep.go writes into
 // the vector source URL. If that rewrite format ever changes (e.g.
@@ -184,6 +252,14 @@ try {
           const filePath = fileURLToPath(url);
           const data = fs.readFileSync(filePath);
           callback(null, { data });
+          return;
+        }
+        if (url.startsWith("https://") || url.startsWith("http://")) {
+          // Async fetch — maplibre-native invokes the callback whenever
+          // we resolve, and won't issue the dependent render until then.
+          fetchRemoteResource(url)
+            .then((data) => callback(null, { data }))
+            .catch((err) => callback(err));
           return;
         }
         callback(new Error(`unsupported url scheme: ${url}`));

--- a/rampardos/internal/services/renderer/styleprep.go
+++ b/rampardos/internal/services/renderer/styleprep.go
@@ -77,13 +77,22 @@ func sourceTileSize(sourceType string, explicit *int) int {
 //     "file://<fontsDir>/{fontstack}/{range}.pbf"
 //     (the {fontstack} and {range} tokens are preserved — they are
 //     resolved per-request by the worker's callback, not here)
-//   - sources.*.url: "mbtiles://<name>"  ->
-//     "mbtiles://<absolute-mbtiles-file>"
-//     (the <name> part is ignored — rampardos uses a single combined
-//     mbtiles per deployment)
+//   - sources.*.url for vector sources (or sources with no explicit
+//     type, which MapLibre defaults to vector) is always rewritten to
+//     "mbtiles://<absolute-mbtiles-file>", regardless of the incoming
+//     scheme. This collapses several upstream variants — "mbtiles://X",
+//     "https://api.maptiler.com/tiles/v3/tiles.json?key={key}",
+//     "mapbox://openmaptiles.X" — onto the operator's combined
+//     mbtiles, which is the only data source the local renderer has.
 //
-// Any http(s)// URLs are left untouched — they are assumed to be
-// legitimate CDN references, not placeholders.
+// Raster, raster-dem, geojson, image, and video source URLs are left
+// alone: they may legitimately point at remote CDNs / tile services
+// (e.g. a hillshade overlay), and the worker's http(s) branch fetches
+// them on demand.
+//
+// http(s) URLs for sprite and glyphs are left untouched — they are
+// assumed to be legitimate CDN references and the worker now fetches
+// and caches them.
 func PrepareStyle(id string, src []byte, cfg Config) ([]byte, error) {
 	// Validate id against path traversal: must be non-empty and contain
 	// only [A-Za-z0-9_-] with no path separators, "..", or null bytes.
@@ -131,11 +140,17 @@ func PrepareStyle(id string, src []byte, cfg Config) ([]byte, error) {
 			if !ok {
 				continue
 			}
-			url, ok := src["url"].(string)
-			if !ok {
+			if _, ok := src["url"].(string); !ok {
 				continue
 			}
-			if strings.HasPrefix(url, "mbtiles://") {
+			// Vector sources (and sources with no explicit type, per
+			// MapLibre's vector default) are always served from the
+			// local combined mbtiles. This covers upstream variants
+			// that would otherwise reach the worker as raw URLs —
+			// MapTiler tiles.json with an unsubstituted {key}, mapbox://
+			// references, etc.
+			srcType, _ := src["type"].(string)
+			if srcType == "vector" || srcType == "" {
 				src["url"] = "mbtiles://" + cfg.MbtilesFile
 			}
 		}

--- a/rampardos/internal/services/renderer/styleprep_test.go
+++ b/rampardos/internal/services/renderer/styleprep_test.go
@@ -80,6 +80,110 @@ func TestPrepareStyleKeepsHTTPGlyphsUnchanged(t *testing.T) {
 	}
 }
 
+// Vector source URLs must be rewritten to the local mbtiles even
+// when the incoming URL is an HTTP TileJSON (the form MapTiler's
+// download-style export uses) or has an unsubstituted {key}
+// placeholder. The previous logic only rewrote mbtiles:// URLs and
+// left these alone, which led to runtime "HTTP 403" failures when the
+// worker tried to fetch the URL directly.
+func TestPrepareStyleRewritesAllVectorSources(t *testing.T) {
+	cfg := Config{StylesDir: "/s", FontsDir: "/f", MbtilesFile: "/d/Combined.mbtiles"}
+	wantURL := "mbtiles:///d/Combined.mbtiles"
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "https TileJSON with {key} placeholder",
+			body: `{"version":8,"sources":{"omt":{"type":"vector","url":"https://api.maptiler.com/tiles/v3/tiles.json?key={key}"}}}`,
+		},
+		{
+			name: "http TileJSON",
+			body: `{"version":8,"sources":{"omt":{"type":"vector","url":"http://example.com/tiles.json"}}}`,
+		},
+		{
+			name: "mapbox:// reference",
+			body: `{"version":8,"sources":{"omt":{"type":"vector","url":"mapbox://openmaptiles.v3"}}}`,
+		},
+		{
+			name: "mbtiles:// placeholder (existing behaviour)",
+			body: `{"version":8,"sources":{"omt":{"type":"vector","url":"mbtiles://openmaptiles"}}}`,
+		},
+		{
+			name: "no type field, defaults to vector",
+			body: `{"version":8,"sources":{"omt":{"url":"https://api.maptiler.com/tiles/v3/tiles.json?key=X"}}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := PrepareStyle("x", []byte(tc.body), cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(out, &parsed); err != nil {
+				t.Fatal(err)
+			}
+			got, _ := parsed["sources"].(map[string]any)["omt"].(map[string]any)["url"].(string)
+			if got != wantURL {
+				t.Errorf("source url: got %q, want %q", got, wantURL)
+			}
+		})
+	}
+}
+
+// Raster, raster-dem, geojson, image, and video sources are NOT
+// rewritten: they may legitimately point at remote CDNs (e.g. a
+// hillshade overlay served from a separate tile service).
+func TestPrepareStyleLeavesNonVectorSourcesAlone(t *testing.T) {
+	cfg := Config{StylesDir: "/s", FontsDir: "/f", MbtilesFile: "/d/Combined.mbtiles"}
+
+	cases := []struct {
+		name      string
+		body      string
+		wantURL   string
+		sourceKey string
+	}{
+		{
+			name:      "raster source",
+			body:      `{"version":8,"sources":{"hill":{"type":"raster","url":"https://hillshade.example.com/tiles.json","tileSize":256}}}`,
+			wantURL:   "https://hillshade.example.com/tiles.json",
+			sourceKey: "hill",
+		},
+		{
+			name:      "raster-dem source",
+			body:      `{"version":8,"sources":{"terrain":{"type":"raster-dem","url":"https://terrain.example.com/tiles.json"}}}`,
+			wantURL:   "https://terrain.example.com/tiles.json",
+			sourceKey: "terrain",
+		},
+		{
+			name:      "geojson source",
+			body:      `{"version":8,"sources":{"places":{"type":"geojson","url":"https://example.com/places.geojson"}}}`,
+			wantURL:   "https://example.com/places.geojson",
+			sourceKey: "places",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := PrepareStyle("x", []byte(tc.body), cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(out, &parsed); err != nil {
+				t.Fatal(err)
+			}
+			got, _ := parsed["sources"].(map[string]any)[tc.sourceKey].(map[string]any)["url"].(string)
+			if got != tc.wantURL {
+				t.Errorf("source url: got %q, want %q (rewrite should only touch vector sources)", got, tc.wantURL)
+			}
+		})
+	}
+}
+
 func TestStyleZoomOffset(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Together these two commits make a MapTiler-exported \`style.json\` work as-is when uploaded via the admin UI. Two distinct bugs, two distinct commits, but they only deliver the user-visible win together — so landing them in one PR.

### Commit 1 — render-worker: fetch + cache remote sprite/glyph URLs (\`rampardos-render-worker/render-worker.js\`)

The worker's request callback only handled \`mbtiles://\` and \`file://\` schemes, so any style referencing a remote sprite (e.g. \`"sprite": "https://raw.githubusercontent.com/.../sprite.png"\`) or remote glyph URL failed at style load with \`unsupported url scheme: …\`.

- Adds an \`http\`/\`https\` branch using Node 18+'s global \`fetch\` with a 30s \`AbortController\` timeout and a 50 MB response cap (both \`Content-Length\` and post-buffer check).
- Persists responses under \`<styleDir>/.remote/<sha256>.<ext>\`. Per-style scope means removing the style directory clears its remote cache; survives worker recycle and process restart; tempfile + rename so concurrent workers racing a cold cache resolve atomically.
- No new CLI arg — cache dir is derived from \`--style-path\`.

### Commit 2 — styleprep: rewrite all vector source URLs to local mbtiles (\`rampardos/internal/services/renderer/styleprep.go\`)

Once HTTPS fetching worked, the next failure was \`HTTP 403 Forbidden for https://api.maptiler.com/tiles/v3/tiles.json?key={key}\` — the worker was faithfully fetching the unsubstituted MapTiler TileJSON URL.

The local renderer's only vector data source is the operator's combined mbtiles, so vector source URLs should resolve to it regardless of what the upstream style.json said. \`PrepareStyle\` now unconditionally rewrites source URLs to \`mbtiles://<combined>\` when the source's type is \`vector\` (or unspecified — MapLibre defaults to vector). Raster, raster-dem, geojson, image, and video sources are left alone since they may legitimately point at external CDNs (hillshade overlays, terrain DEMs) and will go through the new http(s) fetch path from commit 1.

Supersedes #27 (cherry-picked here).

## Test plan

- [ ] Style.json with an HTTPS sprite URL (\`https://raw.githubusercontent.com/.../sprite.png\`): render returns 200; \`TileServer/Styles/<id>/.remote/\` contains the cached sprite file.
- [ ] Style.json with a MapTiler vector source URL (\`https://api.maptiler.com/tiles/v3/tiles.json?key={key}\`): renders against the local mbtiles without ever reaching MapTiler.
- [ ] Style.json with both — MapTiler vector source AND external HTTPS sprite: works in one render (the vector source is short-circuited, the sprite goes through cache).
- [ ] Restart the container, render again: no network fetch — sprite served from \`.remote/\`.
- [ ] \`rm -rf TileServer/Styles/<id>/.remote/\`: next render re-fetches and re-populates.
- [ ] Style with a vector source and a raster overlay pointing at an external tile service: vector goes through the mbtiles, raster URL is left intact and gets fetched + cached by the worker.

Unit-test coverage added in commit 2 for: MapTiler \`{key}\` URLs, \`mapbox://\` URLs, the existing \`mbtiles://\` placeholder (regression), sources with no \`type\` field, and explicit non-rewrite for raster/raster-dem/geojson sources.

🤖 Generated with [Claude Code](https://claude.ai/code)