### PR TITLE
fix(styleprep): rewrite all vector source URLs to local mbtiles

### DIFF
--- a/rampardos/internal/services/renderer/styleprep.go
+++ b/rampardos/internal/services/renderer/styleprep.go
@@ -77,13 +77,22 @@ func sourceTileSize(sourceType string, explicit *int) int {
 //     "file://<fontsDir>/{fontstack}/{range}.pbf"
 //     (the {fontstack} and {range} tokens are preserved — they are
 //     resolved per-request by the worker's callback, not here)
-//   - sources.*.url: "mbtiles://<name>"  ->
-//     "mbtiles://<absolute-mbtiles-file>"
-//     (the <name> part is ignored — rampardos uses a single combined
-//     mbtiles per deployment)
+//   - sources.*.url for vector sources (or sources with no explicit
+//     type, which MapLibre defaults to vector) is always rewritten to
+//     "mbtiles://<absolute-mbtiles-file>", regardless of the incoming
+//     scheme. This collapses several upstream variants — "mbtiles://X",
+//     "https://api.maptiler.com/tiles/v3/tiles.json?key={key}",
+//     "mapbox://openmaptiles.X" — onto the operator's combined
+//     mbtiles, which is the only data source the local renderer has.
 //
-// Any http(s)// URLs are left untouched — they are assumed to be
-// legitimate CDN references, not placeholders.
+// Raster, raster-dem, geojson, image, and video source URLs are left
+// alone: they may legitimately point at remote CDNs / tile services
+// (e.g. a hillshade overlay), and the worker's http(s) branch fetches
+// them on demand.
+//
+// http(s) URLs for sprite and glyphs are left untouched — they are
+// assumed to be legitimate CDN references and the worker now fetches
+// and caches them.
 func PrepareStyle(id string, src []byte, cfg Config) ([]byte, error) {
 	// Validate id against path traversal: must be non-empty and contain
 	// only [A-Za-z0-9_-] with no path separators, "..", or null bytes.
@@ -131,11 +140,17 @@ func PrepareStyle(id string, src []byte, cfg Config) ([]byte, error) {
 			if !ok {
 				continue
 			}
-			url, ok := src["url"].(string)
-			if !ok {
+			if _, ok := src["url"].(string); !ok {
 				continue
 			}
-			if strings.HasPrefix(url, "mbtiles://") {
+			// Vector sources (and sources with no explicit type, per
+			// MapLibre's vector default) are always served from the
+			// local combined mbtiles. This covers upstream variants
+			// that would otherwise reach the worker as raw URLs —
+			// MapTiler tiles.json with an unsubstituted {key}, mapbox://
+			// references, etc.
+			srcType, _ := src["type"].(string)
+			if srcType == "vector" || srcType == "" {
 				src["url"] = "mbtiles://" + cfg.MbtilesFile
 			}
 		}

--- a/rampardos/internal/services/renderer/styleprep_test.go
+++ b/rampardos/internal/services/renderer/styleprep_test.go
@@ -80,6 +80,110 @@ func TestPrepareStyleKeepsHTTPGlyphsUnchanged(t *testing.T) {
 	}
 }
 
+// Vector source URLs must be rewritten to the local mbtiles even
+// when the incoming URL is an HTTP TileJSON (the form MapTiler's
+// download-style export uses) or has an unsubstituted {key}
+// placeholder. The previous logic only rewrote mbtiles:// URLs and
+// left these alone, which led to runtime "HTTP 403" failures when the
+// worker tried to fetch the URL directly.
+func TestPrepareStyleRewritesAllVectorSources(t *testing.T) {
+	cfg := Config{StylesDir: "/s", FontsDir: "/f", MbtilesFile: "/d/Combined.mbtiles"}
+	wantURL := "mbtiles:///d/Combined.mbtiles"
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "https TileJSON with {key} placeholder",
+			body: `{"version":8,"sources":{"omt":{"type":"vector","url":"https://api.maptiler.com/tiles/v3/tiles.json?key={key}"}}}`,
+		},
+		{
+			name: "http TileJSON",
+			body: `{"version":8,"sources":{"omt":{"type":"vector","url":"http://example.com/tiles.json"}}}`,
+		},
+		{
+			name: "mapbox:// reference",
+			body: `{"version":8,"sources":{"omt":{"type":"vector","url":"mapbox://openmaptiles.v3"}}}`,
+		},
+		{
+			name: "mbtiles:// placeholder (existing behaviour)",
+			body: `{"version":8,"sources":{"omt":{"type":"vector","url":"mbtiles://openmaptiles"}}}`,
+		},
+		{
+			name: "no type field, defaults to vector",
+			body: `{"version":8,"sources":{"omt":{"url":"https://api.maptiler.com/tiles/v3/tiles.json?key=X"}}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := PrepareStyle("x", []byte(tc.body), cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(out, &parsed); err != nil {
+				t.Fatal(err)
+			}
+			got, _ := parsed["sources"].(map[string]any)["omt"].(map[string]any)["url"].(string)
+			if got != wantURL {
+				t.Errorf("source url: got %q, want %q", got, wantURL)
+			}
+		})
+	}
+}
+
+// Raster, raster-dem, geojson, image, and video sources are NOT
+// rewritten: they may legitimately point at remote CDNs (e.g. a
+// hillshade overlay served from a separate tile service).
+func TestPrepareStyleLeavesNonVectorSourcesAlone(t *testing.T) {
+	cfg := Config{StylesDir: "/s", FontsDir: "/f", MbtilesFile: "/d/Combined.mbtiles"}
+
+	cases := []struct {
+		name      string
+		body      string
+		wantURL   string
+		sourceKey string
+	}{
+		{
+			name:      "raster source",
+			body:      `{"version":8,"sources":{"hill":{"type":"raster","url":"https://hillshade.example.com/tiles.json","tileSize":256}}}`,
+			wantURL:   "https://hillshade.example.com/tiles.json",
+			sourceKey: "hill",
+		},
+		{
+			name:      "raster-dem source",
+			body:      `{"version":8,"sources":{"terrain":{"type":"raster-dem","url":"https://terrain.example.com/tiles.json"}}}`,
+			wantURL:   "https://terrain.example.com/tiles.json",
+			sourceKey: "terrain",
+		},
+		{
+			name:      "geojson source",
+			body:      `{"version":8,"sources":{"places":{"type":"geojson","url":"https://example.com/places.geojson"}}}`,
+			wantURL:   "https://example.com/places.geojson",
+			sourceKey: "places",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := PrepareStyle("x", []byte(tc.body), cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(out, &parsed); err != nil {
+				t.Fatal(err)
+			}
+			got, _ := parsed["sources"].(map[string]any)[tc.sourceKey].(map[string]any)["url"].(string)
+			if got != tc.wantURL {
+				t.Errorf("source url: got %q, want %q (rewrite should only touch vector sources)", got, tc.wantURL)
+			}
+		})
+	}
+}
+
 func TestStyleZoomOffset(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Previously \`PrepareStyle\` only rewrote source URLs that started with \`mbtiles://\`; anything else (most notably MapTiler's TileJSON URL with an unsubstituted \`{key}\` placeholder, or \`mapbox://\` references) was passed through verbatim. With the worker change in #26 that faithfully fetches \`http(s)\` URLs, these now produce \`HTTP 403 Forbidden for https://api.maptiler.com/tiles/v3/tiles.json?key={key}\` errors at style load instead of the older \`unsupported url scheme:\` error.

The local renderer's only vector data source is the operator's combined mbtiles. Every vector source URL should resolve to it, regardless of what the upstream \`style.json\` said. \`PrepareStyle\` now unconditionally rewrites source URLs to \`mbtiles://<combined>\` when the source's type is \`vector\` (or unspecified — MapLibre defaults to vector).

Raster, raster-dem, geojson, image, and video sources are left alone since they may legitimately point at external CDNs (hillshade overlays, terrain DEMs, etc.).

**Net effect for users**: a \`style.json\` downloaded directly from MapTiler's editor — with the online vector source URL intact — now renders against the local mbtiles without any manual \`sed\` step before upload.

## Test plan

- [ ] Upload a style.json whose vector source URL is the bare MapTiler form (\`https://api.maptiler.com/tiles/v3/tiles.json?key={key}\`); confirm it renders against the local mbtiles instead of erroring.
- [ ] Same for a style with \`mapbox://openmaptiles.X\` as the source URL.
- [ ] Same for the existing \`mbtiles://openmaptiles\` placeholder (regression check).
- [ ] Style with a vector source AND a raster overlay (e.g. external hillshade): vector goes through the mbtiles, raster source URL is left intact and gets fetched + cached by the worker via #26's http(s) branch.

Unit-test coverage added for all four cases above.

🤖 Generated with [Claude Code](https://claude.ai/code)