### PR TITLE
feat(renderer): pre-materialise composite font directories at style load

### DIFF
--- a/rampardos/internal/services/renderer/glyphcomposite.go
+++ b/rampardos/internal/services/renderer/glyphcomposite.go
@@ -1,0 +1,373 @@
+package renderer
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/lenisko/rampardos/internal/services"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// Mapbox glyph PBF wire schema (paraphrased from the upstream .proto):
+//
+//	message glyphs    { repeated fontstack stacks = 1; }
+//	message fontstack { required string name = 1; required string range = 2;
+//	                    repeated glyph glyphs = 3; }
+//	message glyph     { required uint32 id = 1; optional bytes bitmap = 2;
+//	                    required uint32 width = 3; required uint32 height = 4;
+//	                    required sint32 left  = 5; required sint32 top    = 6;
+//	                    required uint32 advance = 7; }
+//
+// The merge operates at the wire level using google.golang.org/protobuf's
+// protowire package — already a transitive dep via prometheus/client_golang,
+// so no new go.mod entries. Each glyph entry from the inputs is kept as
+// raw bytes; only the id field is read for dedup. The output is wrapped
+// in a fresh glyphs/fontstack with the compound name. No per-field
+// decode/encode of glyph bodies.
+const (
+	fieldGlyphsStacks   = 1
+	fieldFontstackName  = 1
+	fieldFontstackRange = 2
+	fieldFontstackGlyph = 3
+	fieldGlyphID        = 1
+	fieldGlyphWidth     = 3 // used in tests; declared here so production and tests share the schema constants
+)
+
+// composeWorkers bounds parallelism within a single composeOneFontstack
+// call. The work is mostly disk I/O — reading a handful of small PBFs
+// per range and writing one — so a small fan-out is enough to overlap
+// kernel work without thrashing.
+const composeWorkers = 8
+
+// CombineGlyphs merges multiple glyph PBF buffers into a single PBF
+// labelled with the compound fontstack name. Inputs are expected to
+// share a range (e.g. "0-255"); the range is taken from the first
+// input that supplies one. Glyphs are deduplicated by id and the
+// earliest input wins — standard MapLibre fontstack fallback, where
+// the first font in the stack covers what it can and later fonts
+// fill the gaps.
+//
+// Callers may pass a single input; the function still rewrites the
+// fontstack name to the compound form so maplibre-native accepts the
+// response for the requested URL.
+func CombineGlyphs(compoundName string, inputs [][]byte) ([]byte, error) {
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("no inputs")
+	}
+	seen := make(map[uint32]struct{})
+	var (
+		entries  [][]byte
+		rangeStr string
+	)
+	for i, in := range inputs {
+		_, r, glyphs, err := parseGlyphsPBF(in)
+		if err != nil {
+			return nil, fmt.Errorf("input %d: %w", i, err)
+		}
+		if rangeStr == "" {
+			rangeStr = r
+		}
+		for _, g := range glyphs {
+			if _, ok := seen[g.id]; ok {
+				continue
+			}
+			seen[g.id] = struct{}{}
+			entries = append(entries, g.body)
+		}
+	}
+	if rangeStr == "" {
+		return nil, fmt.Errorf("no range field in any input")
+	}
+	return encodeGlyphsPBF(compoundName, rangeStr, entries), nil
+}
+
+type rawGlyph struct {
+	id   uint32
+	body []byte // sub-slice of the input buffer — no copy
+}
+
+// parseGlyphsPBF walks one glyphs PBF and returns the fontstack name,
+// range string, and glyph entries (as raw bytes paired with their
+// ids). Multi-stack inputs are flattened: glyphs from every stack
+// are appended in order, and the first non-empty name/range wins.
+func parseGlyphsPBF(data []byte) (name, rangeStr string, glyphs []rawGlyph, err error) {
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if perr := protowire.ParseError(n); perr != nil {
+			return "", "", nil, perr
+		}
+		data = data[n:]
+		if num != fieldGlyphsStacks || typ != protowire.BytesType {
+			skip := protowire.ConsumeFieldValue(num, typ, data)
+			if perr := protowire.ParseError(skip); perr != nil {
+				return "", "", nil, perr
+			}
+			data = data[skip:]
+			continue
+		}
+		stack, sn := protowire.ConsumeBytes(data)
+		if perr := protowire.ParseError(sn); perr != nil {
+			return "", "", nil, perr
+		}
+		data = data[sn:]
+		for len(stack) > 0 {
+			inNum, inTyp, inN := protowire.ConsumeTag(stack)
+			if perr := protowire.ParseError(inN); perr != nil {
+				return "", "", nil, perr
+			}
+			stack = stack[inN:]
+			switch {
+			case inNum == fieldFontstackName && inTyp == protowire.BytesType:
+				v, vn := protowire.ConsumeBytes(stack)
+				if perr := protowire.ParseError(vn); perr != nil {
+					return "", "", nil, perr
+				}
+				if name == "" {
+					name = string(v)
+				}
+				stack = stack[vn:]
+			case inNum == fieldFontstackRange && inTyp == protowire.BytesType:
+				v, vn := protowire.ConsumeBytes(stack)
+				if perr := protowire.ParseError(vn); perr != nil {
+					return "", "", nil, perr
+				}
+				if rangeStr == "" {
+					rangeStr = string(v)
+				}
+				stack = stack[vn:]
+			case inNum == fieldFontstackGlyph && inTyp == protowire.BytesType:
+				v, vn := protowire.ConsumeBytes(stack)
+				if perr := protowire.ParseError(vn); perr != nil {
+					return "", "", nil, perr
+				}
+				stack = stack[vn:]
+				id, perr := extractGlyphID(v)
+				if perr != nil {
+					return "", "", nil, fmt.Errorf("glyph id: %w", perr)
+				}
+				glyphs = append(glyphs, rawGlyph{id: id, body: v})
+			default:
+				skip := protowire.ConsumeFieldValue(inNum, inTyp, stack)
+				if perr := protowire.ParseError(skip); perr != nil {
+					return "", "", nil, perr
+				}
+				stack = stack[skip:]
+			}
+		}
+	}
+	return name, rangeStr, glyphs, nil
+}
+
+// extractGlyphID scans a glyph message for its id field. The schema
+// lists id as field 1, but proto encoders aren't required to emit
+// fields in number order — scan defensively rather than assume.
+func extractGlyphID(glyph []byte) (uint32, error) {
+	data := glyph
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if perr := protowire.ParseError(n); perr != nil {
+			return 0, perr
+		}
+		data = data[n:]
+		if num == fieldGlyphID && typ == protowire.VarintType {
+			v, vn := protowire.ConsumeVarint(data)
+			if perr := protowire.ParseError(vn); perr != nil {
+				return 0, perr
+			}
+			return uint32(v), nil
+		}
+		skip := protowire.ConsumeFieldValue(num, typ, data)
+		if perr := protowire.ParseError(skip); perr != nil {
+			return 0, perr
+		}
+		data = data[skip:]
+	}
+	return 0, fmt.Errorf("glyph entry missing required id field")
+}
+
+func encodeGlyphsPBF(name, rangeStr string, glyphBodies [][]byte) []byte {
+	var stack []byte
+	stack = protowire.AppendTag(stack, fieldFontstackName, protowire.BytesType)
+	stack = protowire.AppendString(stack, name)
+	stack = protowire.AppendTag(stack, fieldFontstackRange, protowire.BytesType)
+	stack = protowire.AppendString(stack, rangeStr)
+	for _, body := range glyphBodies {
+		stack = protowire.AppendTag(stack, fieldFontstackGlyph, protowire.BytesType)
+		stack = protowire.AppendBytes(stack, body)
+	}
+	var out []byte
+	out = protowire.AppendTag(out, fieldGlyphsStacks, protowire.BytesType)
+	out = protowire.AppendBytes(out, stack)
+	return out
+}
+
+var glyphRangeRe = regexp.MustCompile(`^\d+-\d+\.pbf$`)
+
+// ExtractTextFonts returns the deduplicated, sorted set of compound
+// fontstacks (length > 1) referenced via `layout.text-font` in the
+// style. Expression-form `text-font` values (e.g. `["literal", […]]`,
+// `["step", …]`) are ignored: only plain string arrays are composed.
+// Operators using expression forms must materialise composites
+// manually.
+func ExtractTextFonts(styleJSON []byte) ([][]string, error) {
+	var style struct {
+		Layers []struct {
+			Layout map[string]json.RawMessage `json:"layout"`
+		} `json:"layers"`
+	}
+	if err := json.Unmarshal(styleJSON, &style); err != nil {
+		return nil, fmt.Errorf("parse style: %w", err)
+	}
+	seen := make(map[string]struct{})
+	var out [][]string
+	for _, layer := range style.Layers {
+		raw, ok := layer.Layout["text-font"]
+		if !ok {
+			continue
+		}
+		var fonts []string
+		if err := json.Unmarshal(raw, &fonts); err != nil {
+			continue
+		}
+		if len(fonts) < 2 {
+			continue
+		}
+		key := strings.Join(fonts, ",")
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, fonts)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.Join(out[i], ",") < strings.Join(out[j], ",")
+	})
+	return out, nil
+}
+
+// EnsureCompositeFontstacks materialises composite font directories
+// for every compound fontstack referenced by the style, by composing
+// each range PBF across the constituent fonts. Idempotent: a target
+// directory that already exists is left alone (delete it to force
+// regeneration).
+//
+// Constituent fonts that aren't installed are skipped. A composite
+// is still generated as long as at least one constituent contributes;
+// the resulting directory has glyphs only from the available fonts,
+// which matches MapLibre's natural fallback behaviour.
+//
+// Stacks containing a font name that would escape fontsDir (path
+// traversal in style-supplied input) are logged and skipped rather
+// than aborting the whole style load.
+func EnsureCompositeFontstacks(styleJSON []byte, fontsDir string) error {
+	stacks, err := ExtractTextFonts(styleJSON)
+	if err != nil {
+		return err
+	}
+	for _, stack := range stacks {
+		if err := composeOneFontstack(fontsDir, stack); err != nil {
+			return fmt.Errorf("compose %q: %w", strings.Join(stack, ","), err)
+		}
+	}
+	return nil
+}
+
+func composeOneFontstack(fontsDir string, fonts []string) error {
+	for _, f := range fonts {
+		if _, err := services.SanitizeName(f); err != nil {
+			// style-supplied font names that look like path traversal
+			// or contain separators are skipped rather than allowed to
+			// reach filepath.Join. Don't fail the whole style load —
+			// other stacks may still be valid.
+			slog.Warn("skipping fontstack with unsafe constituent name",
+				"stack", strings.Join(fonts, ","), "constituent", f, "error", err)
+			return nil
+		}
+	}
+	compound := strings.Join(fonts, ",")
+	target := filepath.Join(fontsDir, compound)
+	if _, err := os.Stat(target); err == nil {
+		return nil
+	}
+
+	rangeSet := make(map[string]struct{})
+	for _, f := range fonts {
+		entries, err := os.ReadDir(filepath.Join(fontsDir, f))
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() && glyphRangeRe.MatchString(e.Name()) {
+				rangeSet[e.Name()] = struct{}{}
+			}
+		}
+	}
+	if len(rangeSet) == 0 {
+		return fmt.Errorf("no constituent fonts installed for compound %q", compound)
+	}
+
+	if err := os.MkdirAll(fontsDir, 0o755); err != nil {
+		return err
+	}
+	tmpDir, err := os.MkdirTemp(fontsDir, ".compose-*")
+	if err != nil {
+		return err
+	}
+
+	// Fan out per range: the work is one read per constituent + one
+	// compose + one write. Bounded by composeWorkers so we don't
+	// thrash the disk on a 100-range Unicode-covering style.
+	g := new(errgroup.Group)
+	g.SetLimit(composeWorkers)
+	for rangeFile := range rangeSet {
+		rangeFile := rangeFile
+		g.Go(func() error {
+			return composeOneRange(fontsDir, fonts, compound, rangeFile, tmpDir)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		os.RemoveAll(tmpDir)
+		return err
+	}
+
+	if err := os.Rename(tmpDir, target); err != nil {
+		// Two style loads referencing the same compound can race here:
+		// both saw the target missing on entry, both composed into
+		// their own tempdir, both try to rename. POSIX fails the
+		// second rename if the target now exists. Accept that — a
+		// sibling produced an equivalent composite — and clean up
+		// our loser tempdir.
+		os.RemoveAll(tmpDir)
+		if _, statErr := os.Stat(target); statErr == nil {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func composeOneRange(fontsDir string, fonts []string, compound, rangeFile, outDir string) error {
+	var inputs [][]byte
+	for _, f := range fonts {
+		data, err := os.ReadFile(filepath.Join(fontsDir, f, rangeFile))
+		if err != nil {
+			continue
+		}
+		inputs = append(inputs, data)
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+	out, err := CombineGlyphs(compound, inputs)
+	if err != nil {
+		return fmt.Errorf("compose %s: %w", rangeFile, err)
+	}
+	return os.WriteFile(filepath.Join(outDir, rangeFile), out, 0o644)
+}

--- a/rampardos/internal/services/renderer/glyphcomposite_test.go
+++ b/rampardos/internal/services/renderer/glyphcomposite_test.go
@@ -1,0 +1,352 @@
+package renderer
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// makeGlyph builds a minimal glyph entry (only the id field, plus a
+// distinctive width to verify the body is preserved verbatim through
+// the merge). Returns the raw protobuf-encoded body (no outer tag).
+func makeGlyph(id, width uint32) []byte {
+	var b []byte
+	b = protowire.AppendTag(b, fieldGlyphID, protowire.VarintType)
+	b = protowire.AppendVarint(b, uint64(id))
+	b = protowire.AppendTag(b, fieldGlyphWidth, protowire.VarintType)
+	b = protowire.AppendVarint(b, uint64(width))
+	return b
+}
+
+// makePBF builds a single-fontstack glyphs PBF from a list of (id,
+// width) pairs. Used as test input.
+func makePBF(name, rangeStr string, pairs [][2]uint32) []byte {
+	var stack []byte
+	stack = protowire.AppendTag(stack, fieldFontstackName, protowire.BytesType)
+	stack = protowire.AppendString(stack, name)
+	stack = protowire.AppendTag(stack, fieldFontstackRange, protowire.BytesType)
+	stack = protowire.AppendString(stack, rangeStr)
+	for _, p := range pairs {
+		g := makeGlyph(p[0], p[1])
+		stack = protowire.AppendTag(stack, fieldFontstackGlyph, protowire.BytesType)
+		stack = protowire.AppendBytes(stack, g)
+	}
+	var out []byte
+	out = protowire.AppendTag(out, fieldGlyphsStacks, protowire.BytesType)
+	out = protowire.AppendBytes(out, stack)
+	return out
+}
+
+// extractGlyphSummary parses a composite PBF and returns:
+// (name, range, [(id, width)...]). Used for round-trip assertions.
+func extractGlyphSummary(t *testing.T, pbf []byte) (string, string, [][2]uint32) {
+	t.Helper()
+	name, rangeStr, glyphs, err := parseGlyphsPBF(pbf)
+	if err != nil {
+		t.Fatalf("parseGlyphsPBF: %v", err)
+	}
+	out := make([][2]uint32, 0, len(glyphs))
+	for _, g := range glyphs {
+		out = append(out, [2]uint32{g.id, extractGlyphWidth(g.body)})
+	}
+	return name, rangeStr, out
+}
+
+func extractGlyphWidth(glyph []byte) uint32 {
+	data := glyph
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		data = data[n:]
+		if num == fieldGlyphWidth && typ == protowire.VarintType {
+			v, _ := protowire.ConsumeVarint(data)
+			return uint32(v)
+		}
+		data = data[protowire.ConsumeFieldValue(num, typ, data):]
+	}
+	return 0
+}
+
+func TestCombineGlyphs_FirstWins(t *testing.T) {
+	// Font A has glyphs 1, 2, 3 with width=10.
+	// Font B has glyphs 2, 3, 4, 5 with width=20.
+	// Expected merge: A's 1, 2, 3 win; B contributes 4, 5. Widths
+	// preserved verbatim from the source.
+	a := makePBF("Metropolis Regular", "0-255",
+		[][2]uint32{{1, 10}, {2, 10}, {3, 10}})
+	b := makePBF("Noto Sans Regular", "0-255",
+		[][2]uint32{{2, 20}, {3, 20}, {4, 20}, {5, 20}})
+
+	merged, err := CombineGlyphs("Metropolis Regular,Noto Sans Regular", [][]byte{a, b})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	name, rangeStr, glyphs := extractGlyphSummary(t, merged)
+
+	if want := "Metropolis Regular,Noto Sans Regular"; name != want {
+		t.Errorf("name: got %q, want %q", name, want)
+	}
+	if rangeStr != "0-255" {
+		t.Errorf("range: got %q, want %q", rangeStr, "0-255")
+	}
+
+	// Order isn't part of the contract, but every id should appear
+	// exactly once with the expected width.
+	want := map[uint32]uint32{1: 10, 2: 10, 3: 10, 4: 20, 5: 20}
+	got := map[uint32]uint32{}
+	for _, g := range glyphs {
+		if _, dup := got[g[0]]; dup {
+			t.Errorf("duplicate id %d in output", g[0])
+		}
+		got[g[0]] = g[1]
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("merge result: got %v, want %v", got, want)
+	}
+}
+
+func TestCombineGlyphs_SingleInputRelabels(t *testing.T) {
+	in := makePBF("Noto Sans Regular", "256-511", [][2]uint32{{42, 7}})
+	out, err := CombineGlyphs("Metropolis Regular,Noto Sans Regular", [][]byte{in})
+	if err != nil {
+		t.Fatal(err)
+	}
+	name, rangeStr, glyphs := extractGlyphSummary(t, out)
+	if want := "Metropolis Regular,Noto Sans Regular"; name != want {
+		t.Errorf("name: got %q, want %q", name, want)
+	}
+	if rangeStr != "256-511" {
+		t.Errorf("range: got %q, want %q", rangeStr, "256-511")
+	}
+	if len(glyphs) != 1 || glyphs[0] != [2]uint32{42, 7} {
+		t.Errorf("glyphs: got %v, want [{42 7}]", glyphs)
+	}
+}
+
+func TestCombineGlyphs_NoInputs(t *testing.T) {
+	if _, err := CombineGlyphs("X", nil); err == nil {
+		t.Error("expected error for empty inputs")
+	}
+}
+
+func TestCombineGlyphs_RangeTakenFromFirst(t *testing.T) {
+	// Pathological: inputs disagree on range. First wins; this
+	// matches what every well-formed caller will do (all inputs from
+	// the same range file).
+	a := makePBF("A", "0-255", [][2]uint32{{1, 10}})
+	b := makePBF("B", "256-511", [][2]uint32{{2, 20}})
+	out, err := CombineGlyphs("A,B", [][]byte{a, b})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, rangeStr, _ := extractGlyphSummary(t, out)
+	if rangeStr != "0-255" {
+		t.Errorf("range: got %q, want %q", rangeStr, "0-255")
+	}
+}
+
+func TestExtractTextFonts(t *testing.T) {
+	style := []byte(`{
+		"version": 8,
+		"layers": [
+			{"id": "bg", "type": "background"},
+			{"id": "label1", "type": "symbol", "layout": {"text-font": ["Metropolis Regular", "Noto Sans Regular"]}},
+			{"id": "label2", "type": "symbol", "layout": {"text-font": ["Metropolis Bold"]}},
+			{"id": "label3", "type": "symbol", "layout": {"text-font": ["Metropolis Regular", "Noto Sans Regular"]}},
+			{"id": "label4", "type": "symbol", "layout": {"text-font": ["Roboto", "Noto Sans CJK SC Regular"]}},
+			{"id": "label5", "type": "symbol", "layout": {"text-font": ["literal", ["Roboto"]]}}
+		]
+	}`)
+	got, err := ExtractTextFonts(style)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := [][]string{
+		{"Metropolis Regular", "Noto Sans Regular"},
+		{"Roboto", "Noto Sans CJK SC Regular"},
+	}
+	// Both ours and `want` are sorted by ExtractTextFonts.
+	sort.Slice(want, func(i, j int) bool {
+		return strings.Join(want[i], ",") < strings.Join(want[j], ",")
+	})
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("text-fonts:\n got %v\nwant %v", got, want)
+	}
+}
+
+func TestEnsureCompositeFontstacks_GeneratesDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// Constituent fonts with overlapping ranges and overlapping glyph
+	// ids. Composite must win-by-first for the shared id.
+	mustWrite := func(font, rangeFile string, pairs [][2]uint32) {
+		t.Helper()
+		fontDir := filepath.Join(dir, font)
+		if err := os.MkdirAll(fontDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(fontDir, rangeFile),
+			makePBF(font, strings.TrimSuffix(rangeFile, ".pbf"), pairs), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("Metropolis Regular", "0-255.pbf", [][2]uint32{{65, 10}, {66, 10}})
+	mustWrite("Metropolis Regular", "256-511.pbf", [][2]uint32{{257, 10}})
+	mustWrite("Noto Sans Regular", "0-255.pbf", [][2]uint32{{66, 20}, {67, 20}})
+	mustWrite("Noto Sans Regular", "512-767.pbf", [][2]uint32{{513, 20}})
+
+	style := []byte(`{
+		"version": 8,
+		"layers": [
+			{"id": "lbl", "type": "symbol",
+			 "layout": {"text-font": ["Metropolis Regular", "Noto Sans Regular"]}}
+		]
+	}`)
+	if err := EnsureCompositeFontstacks(style, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	composite := filepath.Join(dir, "Metropolis Regular,Noto Sans Regular")
+	if _, err := os.Stat(composite); err != nil {
+		t.Fatalf("composite dir not created: %v", err)
+	}
+
+	check := func(rangeFile string, wantGlyphs map[uint32]uint32) {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(composite, rangeFile))
+		if err != nil {
+			t.Fatalf("read %s: %v", rangeFile, err)
+		}
+		name, _, glyphs := extractGlyphSummary(t, data)
+		if want := "Metropolis Regular,Noto Sans Regular"; name != want {
+			t.Errorf("%s name: got %q, want %q", rangeFile, name, want)
+		}
+		got := map[uint32]uint32{}
+		for _, g := range glyphs {
+			got[g[0]] = g[1]
+		}
+		if !reflect.DeepEqual(got, wantGlyphs) {
+			t.Errorf("%s glyphs: got %v, want %v", rangeFile, got, wantGlyphs)
+		}
+	}
+
+	// 0-255: Metropolis covers 65,66 (width 10); Noto adds 67 (width 20);
+	// 66 is shared so Metropolis (first) wins.
+	check("0-255.pbf", map[uint32]uint32{65: 10, 66: 10, 67: 20})
+	// 256-511: only Metropolis has this range.
+	check("256-511.pbf", map[uint32]uint32{257: 10})
+	// 512-767: only Noto has this range; composite is still produced
+	// with the compound name.
+	check("512-767.pbf", map[uint32]uint32{513: 20})
+}
+
+func TestEnsureCompositeFontstacks_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	fontDir := filepath.Join(dir, "Solo Font")
+	if err := os.MkdirAll(fontDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fontDir, "0-255.pbf"),
+		makePBF("Solo Font", "0-255", [][2]uint32{{1, 1}}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	style := []byte(`{"layers":[{"id":"x","type":"symbol","layout":{"text-font":["Solo Font","Other"]}}]}`)
+	if err := EnsureCompositeFontstacks(style, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Touch a sentinel inside the composite dir; if re-running blows
+	// it away the sentinel disappears.
+	composite := filepath.Join(dir, "Solo Font,Other")
+	if err := os.WriteFile(filepath.Join(composite, "sentinel"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureCompositeFontstacks(style, dir); err != nil {
+		t.Fatalf("re-run failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(composite, "sentinel")); err != nil {
+		t.Errorf("sentinel was removed; composite is not idempotent: %v", err)
+	}
+}
+
+func TestEnsureCompositeFontstacks_UnsafeNamesSkipped(t *testing.T) {
+	// A style with a path-traversal-shaped constituent must not cause
+	// any filesystem operations outside fontsDir. The malicious stack
+	// is skipped (logged); a sibling valid stack still processes.
+	dir := t.TempDir()
+	fontDir := filepath.Join(dir, "Noto Sans Regular")
+	if err := os.MkdirAll(fontDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fontDir, "0-255.pbf"),
+		makePBF("Noto Sans Regular", "0-255", [][2]uint32{{1, 1}}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	otherDir := filepath.Join(dir, "Other Font")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "0-255.pbf"),
+		makePBF("Other Font", "0-255", [][2]uint32{{2, 2}}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	style := []byte(`{"layers":[
+		{"id":"bad","type":"symbol","layout":{"text-font":["../../etc/passwd","Other Font"]}},
+		{"id":"ok","type":"symbol","layout":{"text-font":["Noto Sans Regular","Other Font"]}}
+	]}`)
+	if err := EnsureCompositeFontstacks(style, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid stack still produced.
+	if _, err := os.Stat(filepath.Join(dir, "Noto Sans Regular,Other Font", "0-255.pbf")); err != nil {
+		t.Errorf("valid sibling stack was not composed: %v", err)
+	}
+	// Malicious stack did not produce a composite anywhere under dir.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "..") || strings.Contains(e.Name(), "passwd") {
+			t.Errorf("path-traversal name reached the filesystem: %q", e.Name())
+		}
+	}
+}
+
+func TestEnsureCompositeFontstacks_MissingFontsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	// Only Noto Sans installed; Metropolis directory is absent.
+	fontDir := filepath.Join(dir, "Noto Sans Regular")
+	if err := os.MkdirAll(fontDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fontDir, "0-255.pbf"),
+		makePBF("Noto Sans Regular", "0-255", [][2]uint32{{65, 5}}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	style := []byte(`{"layers":[{"id":"x","type":"symbol","layout":{"text-font":["Metropolis Regular","Noto Sans Regular"]}}]}`)
+	if err := EnsureCompositeFontstacks(style, dir); err != nil {
+		t.Fatalf("expected success with missing constituent: %v", err)
+	}
+	composite := filepath.Join(dir, "Metropolis Regular,Noto Sans Regular", "0-255.pbf")
+	data, err := os.ReadFile(composite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name, _, glyphs := extractGlyphSummary(t, data)
+	if want := "Metropolis Regular,Noto Sans Regular"; name != want {
+		t.Errorf("name: got %q, want %q", name, want)
+	}
+	if len(glyphs) != 1 || glyphs[0] != [2]uint32{65, 5} {
+		t.Errorf("glyphs: got %v, want [{65 5}]", glyphs)
+	}
+}

--- a/rampardos/internal/services/renderer/nodepool.go
+++ b/rampardos/internal/services/renderer/nodepool.go
@@ -192,6 +192,17 @@ func (npr *NodePoolRenderer) loadPool(id string, ratio int) (*stylePool, error) 
 		return nil, fmt.Errorf("prepare style: %w", err)
 	}
 
+	// Materialise composite font directories for any compound
+	// `text-font` arrays in the style. The render worker resolves
+	// glyph URLs by reading <fontsDir>/<fontstack>/<range>.pbf
+	// verbatim, so a stack like ["Metropolis Regular","Noto Sans
+	// Regular"] needs a real directory at <fontsDir>/Metropolis
+	// Regular,Noto Sans Regular/. We generate one here from the
+	// constituent fonts so the worker stays a thin file-reader.
+	if err := EnsureCompositeFontstacks(raw, npr.cfg.FontsDir); err != nil {
+		return nil, fmt.Errorf("compose fontstacks: %w", err)
+	}
+
 	// Atomic write via tempfile + rename: ReloadStyles calls loadPool
 	// outside any lock, so plain os.WriteFile's truncate window would
 	// let a worker spawning in parallel read a zero-length or partial


### PR DESCRIPTION
## Summary

Fixes \`ENOENT: no such file or directory, open '/app/TileServer/Fonts/Metropolis Regular,Noto Sans Regular/7680-7935.pbf'\` and the broader class of "compound fontstack fails to load" errors.

MapLibre Native asks for glyph PBFs via a single URL that encodes the entire fontstack: a style declaring \`text-font: ["Metropolis Regular", "Noto Sans Regular"]\` produces requests for \`<fontsDir>/Metropolis Regular,Noto Sans Regular/<range>.pbf\`. The render worker resolves \`file://\` URLs by reading the file verbatim, so a literal \`Metropolis Regular,Noto Sans Regular\` directory has to exist on disk; otherwise ENOENT bubbles out mid-render.

This PR does the merge ahead of time, in Go, at style load:

### Approach

- **\`CombineGlyphs\`** walks input PBFs at the protobuf wire level via \`google.golang.org/protobuf/encoding/protowire\` — already a transitive dep (via \`prometheus/client_golang\`), so no \`go.mod\` additions. Each glyph entry's raw bytes are preserved verbatim; only the \`id\` field is peeked for dedup. First input wins per id, which is standard MapLibre fontstack-fallback semantics: where Metropolis has a glyph, Metropolis wins; for codepoints Metropolis is missing, Noto fills in.
- **\`ExtractTextFonts\`** scans the style.json for \`layout.text-font\` arrays of length > 1.
- **\`EnsureCompositeFontstacks\`** materialises each compound directory under \`<fontsDir>/\`, writing into a sibling tempdir and renaming on completion so concurrent style loads never see a half-populated target. **Idempotent**: an existing composite directory is left alone (delete it to force regeneration).
- **\`loadPool\`** calls \`EnsureCompositeFontstacks\` alongside \`PrepareStyle\`. The render worker is **unchanged** — \`file://\` finds the pre-materialised PBFs as ordinary files.

### Why pure Go (not fontnik / glyph-pbf-composite)

The Mapbox glyphs schema is small (3 messages, ~7 fields). Doing the merge with \`protowire\` is ~120 lines, copying glyph bytes verbatim with no per-field decode/encode. Avoids:

- A new Node CLI script + symlink in the Docker image
- Forking Node per fontstack per style load
- The render worker growing a runtime npm dependency

### Behaviour on missing constituents

A constituent font that isn't installed is silently skipped. A composite is still produced as long as at least one constituent contributes — operators running with only Noto Sans get Noto Sans glyphs when a style declares \`[Metropolis Regular, Noto Sans Regular]\`, instead of a hard failure. Matches Mapbox's \`glyph-pbf-composite\` behaviour.

## Test plan

Unit tests cover (\`glyphcomposite_test.go\`):

- [x] **First-wins merge**: two inputs with overlapping ids; output retains earliest input's bytes for shared ids and adds non-overlapping ids from later inputs.
- [x] **Single-input relabel**: one input through \`CombineGlyphs\` returns the same glyphs under the requested compound name.
- [x] **No inputs**: error.
- [x] **Range-from-first**: range string taken from the first input that supplies one.
- [x] **\`text-font\` extraction**: dedupes, sorts, ignores length-1 arrays and expression forms (\`["literal", […]]\`).
- [x] **Directory generation**: end-to-end \`EnsureCompositeFontstacks\` produces the correct PBFs across multiple range files.
- [x] **Idempotent**: re-running with an existing composite directory doesn't blow it away (verified via sentinel file).
- [x] **Missing constituents**: a stack \`[Metropolis, Noto Sans]\` on a server with only Noto Sans installed produces a usable directory containing Noto Sans glyphs.

Manual verification I'd run on a real deploy:

- [ ] Upload a MapTiler-format style.json that uses \`["Metropolis Regular", "Noto Sans Regular"]\`. First tile render after the upload should succeed — confirm \`<fontsDir>/Metropolis Regular,Noto Sans Regular/\` appears on disk.
- [ ] Render a tile that hits a high-codepoint range (CJK, emoji); the corresponding range file should also be present in the composite dir.
- [ ] Delete the composite dir, render again, confirm it regenerates on the next style-load path.

🤖 Generated with [Claude Code](https://claude.ai/code)