### PR TITLE
chore: add golangci-lint config and fix the findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,11 @@ tidy:
 fmt:
 	$(GOFMT) -s -w $(GO_DIR)
 
-## lint: Run linter (requires golangci-lint)
+## lint: Run golangci-lint. Must run on Linux with CGO — see .golangci.yml.
 lint:
 	@which golangci-lint > /dev/null || (echo "Install: brew install golangci-lint" && exit 1)
-	cd $(GO_DIR) && golangci-lint run
+	@[ "$$(go env GOOS)" = "linux" ] || echo "WARNING: not Linux — GOOS-constrained files are not analysed, and helpers they use are reported as unused."
+	cd $(GO_DIR) && CGO_ENABLED=1 golangci-lint run
 
 ## docker-build: Build multi-arch Docker image locally
 docker-build:

--- a/rampardos/.golangci.yml
+++ b/rampardos/.golangci.yml
@@ -1,0 +1,75 @@
+version: "2"
+
+# Lint must run on Linux with CGO enabled, or it reports nonsense: the
+# renderer is Linux-only (gopool_linux.go, egl_linux.go), so on macOS the
+# helpers those files use look unused and the renderer itself is never
+# analysed at all. `make lint` and the CI test stage both satisfy this.
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+  settings:
+    errcheck:
+      # Deferred cleanup on a value we are finished with is the accepted Go
+      # idiom, and there is nothing useful to do with the error: the write
+      # path already checks the errors that decide correctness. Listing the
+      # functions explicitly keeps errcheck meaningful everywhere else
+      # rather than switching the linter off wholesale.
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+        - (*net/http.Response).Body.Close
+        - (*archive/zip.Writer).Close
+        - (*compress/flate.Writer).Close
+        - os.Remove
+        - os.RemoveAll
+        - os.MkdirAll
+        # Writes to a client that has already gone. By the time these fail
+        # the handler has committed to its outcome and the connection is
+        # dead; there is no recovery and no second channel to report on.
+        - (net/http.ResponseWriter).Write
+        - (*encoding/json.Encoder).Encode
+        - (*github.com/gorilla/websocket.Conn).WriteMessage
+        - (*github.com/gorilla/websocket.Conn).Close
+        # Read side of a multipart request: closing after the body has been
+        # consumed reports nothing the handler can act on.
+        - (*mime/multipart.Part).Close
+
+    staticcheck:
+      # QF* are "quickfix" style suggestions, not correctness findings, and
+      # QF1001 (De Morgan's law) actively hurts the one place it fires: a
+      # character whitelist reads far more clearly as "not one of these
+      # allowed classes" than as a chain of negated comparisons.
+      # golangci-lint's default set, minus QF1001. Spelled out rather than
+      # written as ["all", "-QF1001"], because "all" also switches on the
+      # ST checks the default deliberately leaves off (package comments,
+      # naming) and would add unrelated noise across the tree.
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        - -QF1001
+
+  exclusions:
+    # Generated and adapted-from-upstream code. pngfast is a fork of the
+    # standard library's image/png tuned for our encode path; keeping it
+    # textually close to upstream matters more than local style, because
+    # divergence makes future syncs harder to review.
+    paths:
+      - internal/utils/pngfast
+
+    rules:
+      # Tests favour readability over defensive error handling on setup
+      # helpers; a failed helper fails the test anyway.
+      - path: _test\.go
+        linters:
+          - errcheck

--- a/rampardos/cmd/server/main.go
+++ b/rampardos/cmd/server/main.go
@@ -435,7 +435,9 @@ func main() {
 	signal.Stop(hupCh)
 	cancelHup()
 	<-hupDone
-	renderEngine.Close()
+	if err := renderEngine.Close(); err != nil {
+		slog.Error("Renderer shutdown", "error", err)
+	}
 
 	// Stop background services first to drain goroutines.
 	if pyroscopeProfiler != nil {

--- a/rampardos/internal/handlers/common.go
+++ b/rampardos/internal/handlers/common.go
@@ -86,7 +86,13 @@ func handlePregenerateResponseBytes(
 		regeneratablePath := fmt.Sprintf("Cache/Regeneratable/%s.json", filepath.Base(path))
 		if _, err := os.Stat(regeneratablePath); os.IsNotExist(err) {
 			if jsonData, err := json.Marshal(data); err == nil {
-				fileutil.AtomicWriteFile(regeneratablePath, jsonData, 0644)
+				// Best effort: the response is already decided, so a failed
+				// marker must not fail the request — but it does mean this
+				// entry will not be treated as regeneratable later, which is
+				// worth knowing about.
+				if err := fileutil.AtomicWriteFile(regeneratablePath, jsonData, 0644); err != nil {
+					slog.Warn("Failed to write regeneratable marker", "path", regeneratablePath, "error", err)
+				}
 			}
 		}
 	}

--- a/rampardos/internal/handlers/views/datasets.go
+++ b/rampardos/internal/handlers/views/datasets.go
@@ -39,12 +39,12 @@ type DatasetItem struct {
 // DatasetsContext is the template context for datasets page
 type DatasetsContext struct {
 	BaseContext
-	PageID         string
-	PageName       string
-	Datasets       []DatasetItem
-	HasUncombined  bool
-	IsCombined     bool   // true if multiple datasets are combined
-	ActiveDataset  string // name of active dataset (empty if combined)
+	PageID        string
+	PageName      string
+	Datasets      []DatasetItem
+	HasUncombined bool
+	IsCombined    bool   // true if multiple datasets are combined
+	ActiveDataset string // name of active dataset (empty if combined)
 }
 
 // DatasetsAddContext is the template context for add dataset page
@@ -125,13 +125,13 @@ func (v *DatasetsView) Render(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := DatasetsContext{
-		BaseContext:    NewBaseContext(),
-		PageID:         "datasets",
-		PageName:       "Datasets",
-		Datasets:       datasets,
-		HasUncombined:  v.datasetsController.HasUncombined(),
-		IsCombined:     isCombined,
-		ActiveDataset:  activeDataset,
+		BaseContext:   NewBaseContext(),
+		PageID:        "datasets",
+		PageName:      "Datasets",
+		Datasets:      datasets,
+		HasUncombined: v.datasetsController.HasUncombined(),
+		IsCombined:    isCombined,
+		ActiveDataset: activeDataset,
 	}
 
 	v.templates.Render(w, "datasets.html", ctx)

--- a/rampardos/internal/services/http.go
+++ b/rampardos/internal/services/http.go
@@ -52,7 +52,11 @@ func (s *HTTPService) getClient(_ string) *http.Client {
 }
 
 // DownloadFile downloads a file from a URL and saves it to the specified path.
-// timeout: timeout for initial response headers (0 = 30s default). Body read has no timeout for large files.
+// timeout is currently ignored: downloads use the shared client, which
+// sets no overall deadline so large dataset files are not cut off
+// mid-transfer. Cancellation is via ctx. The parameter is kept so callers
+// do not have to change, but passing a value has no effect — do not rely
+// on it to bound a download.
 func DownloadFile(ctx context.Context, fromURL, toPath, expectedType string, timeout time.Duration) error {
 	if globalHTTPService == nil {
 		return fmt.Errorf("HTTP service not initialized")
@@ -63,10 +67,6 @@ func DownloadFile(ctx context.Context, fromURL, toPath, expectedType string, tim
 		return fmt.Errorf("invalid URL: %w", err)
 	}
 	host := parsedURL.Host
-
-	if timeout == 0 {
-		timeout = 30 * time.Second
-	}
 
 	startTime := time.Now()
 	GlobalMetrics.RecordHTTPClientRequest(host)

--- a/rampardos/internal/services/metrics.go
+++ b/rampardos/internal/services/metrics.go
@@ -865,7 +865,7 @@ func (m *MetricsManager) GetTemplateRenderStats() []TemplateRenderStat {
 	}()
 
 	for metric := range ch {
-		var pm prometheus.Metric = metric
+		pm := metric
 		var dto prommodel.Metric
 		if err := pm.Write(&dto); err != nil {
 			continue

--- a/rampardos/internal/services/renderer/pool.go
+++ b/rampardos/internal/services/renderer/pool.go
@@ -131,7 +131,9 @@ func (p *stylePool) replaceWorker() {
 		// now short one worker until next successful spawn; this is
 		// acceptable — dispatch still blocks waiting for any idle
 		// worker, and callers' context deadlines bound the wait.
-		fmt.Fprintf(osStderr, "renderer: failed to replace worker for style %q: %v\n", p.cfg.styleID, err)
+		// Best effort: this is the error path of the error path, and there
+		// is nowhere left to report to if stderr itself fails.
+		_, _ = fmt.Fprintf(osStderr, "renderer: failed to replace worker for style %q: %v\n", p.cfg.styleID, err)
 		return
 	}
 	// Re-check closed under lock before sending. close() may have run

--- a/rampardos/internal/services/templates.go
+++ b/rampardos/internal/services/templates.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -81,10 +82,15 @@ func (tc *TemplatesController) SaveTemplate(name, oldName, content string) error
 	path := filepath.Join(tc.folder, sanitized+".json")
 
 	// Create backup of existing file before saving
+	// A failed backup must not fail the save — the user asked to write the
+	// template, not to keep a copy — but it does need to be visible, because
+	// silently skipping it leaves them believing a recovery point exists.
 	if existingContent, err := os.ReadFile(path); err == nil {
 		timestamp := time.Now().Unix()
 		backupPath := filepath.Join(tc.folder, fmt.Sprintf("%s.json.%d", sanitized, timestamp))
-		os.WriteFile(backupPath, existingContent, 0644)
+		if err := os.WriteFile(backupPath, existingContent, 0644); err != nil {
+			slog.Warn("Failed to back up template before overwrite", "template", sanitized, "backup", backupPath, "error", err)
+		}
 	}
 
 	return os.WriteFile(path, []byte(content), 0644)
@@ -149,8 +155,12 @@ func (tc *TemplatesController) DeleteTemplate(name string) error {
 	if err != nil {
 		return err
 	}
-	// Also remove test data if exists
-	tc.DeleteTestData(name)
+	// Also remove test data if exists. The template itself is already
+	// deleted, so a failure here leaves an orphaned test file rather than
+	// an inconsistent template — worth reporting, not worth failing on.
+	if err := tc.DeleteTestData(name); err != nil {
+		slog.Warn("Failed to delete template test data", "template", name, "error", err)
+	}
 	return nil
 }
 

--- a/rampardos/internal/utils/image_utils_native.go
+++ b/rampardos/internal/utils/image_utils_native.go
@@ -622,10 +622,24 @@ func parseColor(s string) color.Color {
 		if len(parts) == 4 {
 			var r, g, b int
 			var a float64
-			fmt.Sscanf(strings.TrimSpace(parts[0]), "%d", &r)
-			fmt.Sscanf(strings.TrimSpace(parts[1]), "%d", &g)
-			fmt.Sscanf(strings.TrimSpace(parts[2]), "%d", &b)
-			fmt.Sscanf(strings.TrimSpace(parts[3]), "%f", &a)
+			// Unchecked, a malformed component left its variable at zero and
+			// the colour came out silently wrong: "rgba(255,x,0,1)" rendered
+			// as black rather than being rejected. Treat an unparseable
+			// component the same as unparseable input elsewhere in this
+			// function — transparent — so a typo is visible rather than
+			// quietly painting the wrong colour.
+			if _, err := fmt.Sscanf(strings.TrimSpace(parts[0]), "%d", &r); err != nil {
+				return color.Transparent
+			}
+			if _, err := fmt.Sscanf(strings.TrimSpace(parts[1]), "%d", &g); err != nil {
+				return color.Transparent
+			}
+			if _, err := fmt.Sscanf(strings.TrimSpace(parts[2]), "%d", &b); err != nil {
+				return color.Transparent
+			}
+			if _, err := fmt.Sscanf(strings.TrimSpace(parts[3]), "%f", &a); err != nil {
+				return color.Transparent
+			}
 			// Use NRGBA (non-premultiplied alpha) for correct transparency
 			return color.NRGBA{uint8(r), uint8(g), uint8(b), uint8(a * 255)}
 		}
@@ -637,9 +651,17 @@ func parseColor(s string) color.Color {
 		parts := strings.Split(inner, ",")
 		if len(parts) == 3 {
 			var r, g, b int
-			fmt.Sscanf(strings.TrimSpace(parts[0]), "%d", &r)
-			fmt.Sscanf(strings.TrimSpace(parts[1]), "%d", &g)
-			fmt.Sscanf(strings.TrimSpace(parts[2]), "%d", &b)
+			// Same hazard as the rgba() branch above: an unparsed component
+			// stayed zero and silently shifted the colour.
+			if _, err := fmt.Sscanf(strings.TrimSpace(parts[0]), "%d", &r); err != nil {
+				return color.Transparent
+			}
+			if _, err := fmt.Sscanf(strings.TrimSpace(parts[1]), "%d", &g); err != nil {
+				return color.Transparent
+			}
+			if _, err := fmt.Sscanf(strings.TrimSpace(parts[2]), "%d", &b); err != nil {
+				return color.Transparent
+			}
 			return color.NRGBA{uint8(r), uint8(g), uint8(b), 255}
 		}
 	}
@@ -650,21 +672,32 @@ func parseColor(s string) color.Color {
 	var r, g, b, a uint8 = 0, 0, 0, 255
 
 	switch len(s) {
+	// A hex string of the right length can still contain non-hex digits.
+	// Unchecked, those components stayed zero and the colour came out
+	// wrong instead of being rejected, so "#ff00zz" rendered as "#ff0000".
 	case 3: // RGB
-		fmt.Sscanf(s, "%1x%1x%1x", &r, &g, &b)
+		if _, err := fmt.Sscanf(s, "%1x%1x%1x", &r, &g, &b); err != nil {
+			return color.Transparent
+		}
 		r *= 17
 		g *= 17
 		b *= 17
 	case 4: // RGBA
-		fmt.Sscanf(s, "%1x%1x%1x%1x", &r, &g, &b, &a)
+		if _, err := fmt.Sscanf(s, "%1x%1x%1x%1x", &r, &g, &b, &a); err != nil {
+			return color.Transparent
+		}
 		r *= 17
 		g *= 17
 		b *= 17
 		a *= 17
 	case 6: // RRGGBB
-		fmt.Sscanf(s, "%02x%02x%02x", &r, &g, &b)
+		if _, err := fmt.Sscanf(s, "%02x%02x%02x", &r, &g, &b); err != nil {
+			return color.Transparent
+		}
 	case 8: // RRGGBBAA
-		fmt.Sscanf(s, "%02x%02x%02x%02x", &r, &g, &b, &a)
+		if _, err := fmt.Sscanf(s, "%02x%02x%02x%02x", &r, &g, &b, &a); err != nil {
+			return color.Transparent
+		}
 	default:
 		// Try named colors
 		switch strings.ToLower(s) {

--- a/rampardos/internal/utils/parsecolor_test.go
+++ b/rampardos/internal/utils/parsecolor_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"image/color"
+	"testing"
+)
+
+// parseColor previously left unparsed components at zero, so malformed
+// input rendered as a plausible-but-wrong colour instead of being
+// rejected. These lock in that valid input is unaffected and invalid
+// input is now visibly transparent rather than silently shifted.
+func TestParseColorRejectsMalformed(t *testing.T) {
+	valid := map[string]color.Color{
+		"#ff0000":        color.NRGBA{255, 0, 0, 255},
+		"rgb(0,128,255)": color.NRGBA{0, 128, 255, 255},
+		"black":          color.Black,
+		"transparent":    color.Transparent,
+	}
+	for in, want := range valid {
+		if got := parseColor(in); got != want {
+			t.Errorf("parseColor(%q) = %v, want %v", in, got, want)
+		}
+	}
+
+	for _, in := range []string{"#ff00zz", "rgb(255,x,0)", "rgba(1,2,zz,1)"} {
+		if got := parseColor(in); got != color.Transparent {
+			t.Errorf("parseColor(%q) = %v, want Transparent (malformed input must not render a wrong colour)", in, got)
+		}
+	}
+}

--- a/rampardos/internal/utils/pngfast/reader.go
+++ b/rampardos/internal/utils/pngfast/reader.go
@@ -1049,4 +1049,3 @@ func DecodeConfig(r io.Reader) (image.Config, error) {
 		Height:     d.height,
 	}, nil
 }
-


### PR DESCRIPTION
Adds a `golangci-lint` config and takes the tree to **zero issues**, so lint can become a gate rather than a report nobody reads.

Split out of #19 (the in-process Go renderer) because none of it is renderer work — it is easier to review, and to revert, on its own.

## Running it

Lint has to run **on Linux with CGO**. GOOS-constrained files are otherwise not analysed at all, and the helpers they use get reported as unused. `make lint` now warns when that is the case.

```
make lint
```

## Configured rather than fixed

Where the linter was wrong, with the reasoning recorded in `.golangci.yml`:

- **errcheck** ignores deferred cleanup, and writes to a client that has already gone (`ResponseWriter.Write`, `json.Encoder.Encode`, websocket writes, read-side `multipart.Part.Close`). By the time those fail the handler has committed to its outcome and there is no second channel to report on. Listed **by function**, so errcheck keeps working everywhere else instead of being switched off wholesale.
- **`internal/utils/pngfast` excluded** — it is a fork of the standard library's `image/png`; divergence from upstream makes future syncs harder to review than local style gains are worth.
- **staticcheck `QF1001` off** — the one place it fires is a character whitelist, which reads far better as *"not one of these allowed classes"* than as a chain of De Morgan'd negations.

## Three real bugs, all from unchecked errors

**`parseColor` silently produced the wrong colour.** An unparsed component stayed at its zero value, so `#ff00zz` rendered as `#ff0000` and `rgb(255,x,0)` as black. A typo in a marker colour became a *plausible* colour rather than a visible failure — the worst kind of wrong. All three parse paths (hex, `rgb()`, `rgba()`) now return transparent on malformed input, and a test covers both that valid input is unaffected and that malformed input no longer renders.

**`DownloadFile` documented `0 = 30s default`** and assigned it — but never used the value. Downloads run on the shared client, which deliberately sets no deadline so large dataset files are not cut off mid-transfer. Callers passing a timeout were relying on something that does not happen. The dead assignment is gone and the comment now says so. *Whether to honour the parameter or drop it is a behaviour decision, deliberately not made here.*

**A template backup write was discarded**, so a failed backup left the user believing a recovery point existed. Now logged — still does not fail the save, since the user asked to write the template, not to keep a copy.

Also logged rather than dropped: the regeneratable-marker write, test-data cleanup on template delete, and renderer shutdown.

## Verification

`golangci-lint`, `go vet`, `go build` and `go test` all clean; `gofmt -l` empty (two files were already unformatted on master and are included).

## Follow-up

Once this lands, #19 rebases onto it and CI can gate on lint.
